### PR TITLE
Renaming OceanParcels to Parcels-code throughout parcels repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See https://docs.oceanparcels.org/en/latest/contributing.html
+See https://docs.parcels-code.org/en/latest/contributing.html

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 contact_links:
   - name: 🙏 Parcels use question, help, or support
-    url: https://github.com/OceanParcels/parcels/discussions/new?category=q-a
+    url: https://github.com/Parcels-code/parcels/discussions/new?category=q-a
     about: Have a question about Parcels? Or do you need troubleshooting for a specific usecase? Then start a Q&A Discussion thread instead, and we'll be happy to help.
   - name: 💬 Other Parcels discussion
-    url: https://github.com/OceanParcels/parcels/discussions
+    url: https://github.com/Parcels-code/parcels/discussions
     about: For general discussion about Parcels, or to share your work with the community, please use the Discussions tab.

--- a/.github/ci/recipe.yaml
+++ b/.github/ci/recipe.yaml
@@ -53,19 +53,16 @@ tests:
         - parcels
 
 about:
-  homepage: https://github.com/OceanParcels/parcels
+  homepage: https://github.com/Parcels-code/parcels
   license: MIT
   license_file: LICENSE.md
-  summary: Probably A Really Computationally Efficient Lagrangian Simulator
+  summary: Parcels - A highly customisable Lagrangian simulation framework
   description: |
-    Parcels (Probably A Really Computationally Efficient Lagrangian Simulator)
-    is a set of Python classes and methods to create customisable particle
-    tracking simulations using output from Ocean Circulation models.
-    Parcels can be used to track passive and active particulates such as
-    water, nutrients, plankton, plastic and fish.
-  documentation: https://oceanparcels.org/
-  repository: https://github.com/OceanParcels/parcels
+    Parcels provides a set of Python classes and methods to create customisable particle tracking simulations using gridded output from (ocean) circulation models.
+  documentation: https://parcels-code.org/
+  repository: https://github.com/Parcels-code/parcels
 
 extra:
   recipe-maintainers:
     - VeckoTheGecko
+    - erikvansebille

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-artifacts:
     runs-on: ubuntu-latest
-    if: github.repository == 'OceanParcels/parcels'
+    if: github.repository == 'Parcels-code/parcels'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -102,5 +102,5 @@ jobs:
           channels: conda-forge
       - run: conda install -c conda-forge pip
       - run: pip install parcels --no-cache
-      - run: curl https://raw.githubusercontent.com/OceanParcels/parcels/main/docs/examples/example_peninsula.py > example_peninsula.py
+      - run: curl https://raw.githubusercontent.com/Parcels-code/parcels/main/docs/examples/example_peninsula.py > example_peninsula.py
       - run: python example_peninsula.py

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,9 +14,9 @@ authors:
     given-names: "Philippe"
     orcid: "https://orcid.org/0000-0003-0100-5834"
   - name: "The Parcels contributors"
-    website: "https://github.com/OceanParcels/parcels/graphs/contributors"
+    website: "https://github.com/Parcels-code/parcels/graphs/contributors"
 title: "Parcels"
 version: 3.1.2
 doi: 10.5281/zenodo.14845686
 date-released: 2025-02-10
-url: "https://github.com/OceanParcels/parcels"
+url: "https://github.com/Parcels-code/parcels"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019, OceanParcels team
+Copyright (c) 2025, Parcels team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@
 [![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![Xarray](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydata/xarray/refs/heads/main/doc/badge.json)](https://xarray.dev)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![unit-tests](https://github.com/OceanParcels/parcels/actions/workflows/ci.yml/badge.svg)](https://github.com/OceanParcels/parcels/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/OceanParcels/parcels/branch/main/graph/badge.svg)](https://codecov.io/gh/OceanParcels/parcels)
+[![unit-tests](https://github.com/Parcels-code/parcels/actions/workflows/ci.yml/badge.svg)](https://github.com/Parcels-code/parcels/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Parcels-code/parcels/branch/main/graph/badge.svg)](https://codecov.io/gh/Parcels-code/parcels)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5353/badge)](https://bestpractices.coreinfrastructure.org/projects/5353)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/OceanParcels/parcels/main?labpath=docs%2Fexamples%2Fparcels_tutorial.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Parcels-code/parcels/main?labpath=docs%2Fexamples%2Fparcels_tutorial.ipynb)
 [![LinkedIn](https://custom-icon-badges.demolab.com/badge/LinkedIn-0A66C2?logo=linkedin-white&logoColor=fff)](https://www.linkedin.com/company/parcelscode/)
 
 > [!WARNING]
 > This branch is `v4-dev` - version 4 of Parcels which is in active development. See `main` (or the tags) to browse stable versions of Parcels.
 
-**Parcels** (**P**robably **A** **R**eally **C**omputationally **E**fficient **L**agrangian **S**imulator) is a set of Python classes and methods to create customisable particle tracking simulations using output from Ocean Circulation models. Parcels can be used to track passive and active particulates such as water, plankton, [plastic](http://www.topios.org/) and [fish](https://github.com/Jacketless/IKAMOANA).
+**Parcels** provides a set of Python classes and methods to create customisable particle tracking simulations using gridded output from (ocean) circulation models. Parcels can be used to track passive and active particulates such as water, plankton, [plastic](http://www.topios.org/) and [fish](https://github.com/Jacketless/IKAMOANA).
 
-![Arctic-SO-medusaParticles](https://github.com/OceanParcels/oceanparcels_website/blob/main/images/homepage.gif)
+![Arctic-SO-medusaParticles](https://github.com/Parcels-code/oceanparcels_website/blob/main/images/homepage.gif)
 
-_Animation of virtual particles carried by ocean surface flow in the global oceans. The particles are advected with [Parcels](http://oceanparcels.org/) in data from the [NEMO Ocean Model](https://www.nemo-ocean.eu/)._
+_Animation of virtual particles carried by ocean surface flow in the global oceans. The particles are advected with [Parcels](http://parcels-code.org/) in data from the [NEMO Ocean Model](https://www.nemo-ocean.eu/)._
 
 ### Parcels manuscript and code
 
@@ -38,13 +38,13 @@ _Kehl, C, PD Nooteboom, MLA Kaandorp and E van Sebille (2023) Efficiently simula
 
 ### Further information
 
-See [oceanparcels.org](http://oceanparcels.org/) for further information about [installing](https://docs.oceanparcels.org/en/latest/installation.html) and [running](https://docs.oceanparcels.org/en/latest/documentation.html) the Parcels code, as well as extended [documentation](https://docs.oceanparcels.org/en/latest/reference.html) of the methods and classes.
+See [parcels-code.org](http://parcels-code.org/) for further information about [installing](https://docs.parcels-code.org/en/latest/installation.html) and [running](https://docs.parcels-code.org/en/latest/documentation.html) the Parcels code, as well as extended [documentation](https://docs.parcels-code.org/en/latest/reference.html) of the methods and classes.
 
 ### Contributors
 
-<a href="https://github.com/oceanparcels/parcels/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=oceanparcels/parcels" />
+<a href="https://github.com/parcels-code/parcels/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=parcels-code/parcels" />
 </a>
 
-**All contributions are welcome! See the [contributing page](https://docs.oceanparcels.org/en/latest/contributing.html) in our documentation to see how to get involved.**
+**All contributions are welcome! See the [contributing page](https://docs.parcels-code.org/en/latest/contributing.html) in our documentation to see how to get involved.**
 Image made with [contrib.rocks](https://contrib.rocks).

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -4,7 +4,7 @@
 
 [Lagrangian Ocean Analysis](https://doi.org/10.1016/j.ocemod.2017.11.008) is one of the primary modelling tools available to oceanographers to understand how ocean currents transport material. This modelling approach allows researchers to model the ocean and understand the [movement of water](https://doi.org/10.1029/2023GL105662) in the ocean itself (or even [on other planets](https://doi.org/10.3847/1538-4357/ac9d94)), as well as the transport of [nutrients](https://doi.org/10.1029/2023GL108001), [marine organisms](https://doi.org/10.3354/meps14526), [oil](https://doi.org/10.1590/0001-3765202220210391), [plastic](https://doi.org/10.1038/s41561-023-01216-0), as well as [almost](https://doi.org/10.1016/j.robot.2024.104730) [anything](https://doi.org/10.1111/cobi.14295) [else](https://doi.org/10.1016/j.marpolbul.2023.115254) that would be adrift at sea. Since ocean currents play a key role in climate by storing heat and carbon, and also in the formation of the 'plastic soup', understanding transport phenomena in the ocean is crucial to support a more sustainable future.
 
-The Parcels code, for which development started in 2015, is now one of the most widely used tools for Lagrangian Ocean Analysis. It's used by dozens of groups around the world - see [this list](https://oceanparcels.org/papers-citing-parcels#papers-citing-parcels) for a full list of the peer-reviewed articles using Parcels. Its flexibility for users to create new, custom 'behaviours' (i.e. let virtual particles be controlled by other mechanics than only the ocean flow) and its compatibility with many different types of hydrodynamic input data are the two key features.
+The Parcels code, for which development started in 2015, is now one of the most widely used tools for Lagrangian Ocean Analysis. It's used by dozens of groups around the world - see [this list](https://parcels-code.org/papers-citing-parcels#papers-citing-parcels) for a full list of the peer-reviewed articles using Parcels. Its flexibility for users to create new, custom 'behaviours' (i.e. let virtual particles be controlled by other mechanics than only the ocean flow) and its compatibility with many different types of hydrodynamic input data are the two key features.
 
 ```{note}
 Want to learn more about Lagrangian ocean analysis? Then look at [Lagrangian ocean analysis: Fundamentals and practices](https://www.sciencedirect.com/science/article/pii/S1463500317301853) for a review of the literature.
@@ -22,7 +22,7 @@ The first component of this documentation is geared to those new to open source.
 
 Open source is a category of software that is open to the public, meaning that anyone is able to look at, modify, and improve the software. Compare this to closed source software (e.g., Microsoft Word, or Gmail) where only those working for the company on the product are able to look at the source code, or make improvements.
 
-Software being open source allows bugs in the code to be quickly identified and fixed, as well as fosters communities of people involved on projects. Most open source software have permissible licenses making them free to modify, and use even in commercial settings. Parcels, for example, is open source and [licensed under the MIT License](https://github.com/OceanParcels/parcels/blob/main/LICENSE.md).
+Software being open source allows bugs in the code to be quickly identified and fixed, as well as fosters communities of people involved on projects. Most open source software have permissible licenses making them free to modify, and use even in commercial settings. Parcels, for example, is open source and [licensed under the MIT License](https://github.com/Parcels-code/parcels/blob/main/LICENSE.md).
 
 This visibility of the codebase results in a higher quality, as well as a more transparent and stable product. This is important in research for reproducibility, as well as in industry where stability is crucial. Open source is not some niche category of software, but in fact [forms the backbone of modern computing and computing infrastructure](https://www.newstatesman.com/science-tech/2016/08/how-linux-conquered-world-without-anyone-noticing) and is used widely in industry. A lot of the digital services that you use (paid, or free) depend on open source code in one way or another.
 
@@ -36,25 +36,25 @@ Exactly how to use Git and GitHub is beyond the scope of this documentation, and
 
 There are many ways that you can contribute to Parcels. You can:
 
-- Participate in discussion about Parcels, either through the [issues](https://github.com/OceanParcels/parcels/issues) or [discussions](https://github.com/OceanParcels/parcels/discussions) tab
+- Participate in discussion about Parcels, either through the [issues](https://github.com/Parcels-code/parcels/issues) or [discussions](https://github.com/Parcels-code/parcels/discussions) tab
 - Suggest improvements to [tutorials](../documentation/index.md)
 - Suggest improvements to [documentation](../index.md)
 - Write code (fix bugs, implement features, codebase improvements, etc)
 
 All of these require you to [make an account on GitHub](https://github.com/signup), so that should be your first step.
 
-If you want to suggest quick edits to the documentation, it's as easy as going to the page and clicking "Edit on GitHub" in the righthand panel. For other changes, it's a matter of looking through the [issue tracker](https://github.com/OceanParcels/parcels/issues) which documents tasks that are being considered. Pay particular attention to [issues tagged with "good first issue"](https://github.com/OceanParcels/parcels/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22), as these are tasks that don't require deep familiarity with the codebase. Once you've chosen an issue you would like to contribute towards, comment on it to flag your interest in working on it. This allows the community to know who's interested, and provide any guidance in its implementation (maybe the scope has changed since the issue was last updated).
+If you want to suggest quick edits to the documentation, it's as easy as going to the page and clicking "Edit on GitHub" in the righthand panel. For other changes, it's a matter of looking through the [issue tracker](https://github.com/Parcels-code/parcels/issues) which documents tasks that are being considered. Pay particular attention to [issues tagged with "good first issue"](https://github.com/Parcels-code/parcels/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22), as these are tasks that don't require deep familiarity with the codebase. Once you've chosen an issue you would like to contribute towards, comment on it to flag your interest in working on it. This allows the community to know who's interested, and provide any guidance in its implementation (maybe the scope has changed since the issue was last updated).
 
-If you're having trouble using Parcels, feel free to create a discussion in our Discussions tab and we'll be happy to support. Want to suggest a feature, or have encountered a problem that is a result of a bug in Parcels, then search for an issue in the tracker or [create a new one](https://github.com/OceanParcels/parcels/issues/new/choose) with the relevant details.
+If you're having trouble using Parcels, feel free to create a discussion in our Discussions tab and we'll be happy to support. Want to suggest a feature, or have encountered a problem that is a result of a bug in Parcels, then search for an issue in the tracker or [create a new one](https://github.com/Parcels-code/parcels/issues/new/choose) with the relevant details.
 
-In the [Projects panel](https://github.com/OceanParcels/parcels/projects?query=is%3Aopen), you'll see the "Parcels development" project. This is used by the core development team for project management, as well as drafting up new ideas for the codebase that aren't mature enough to be issues themselves. Everything in "backlog" is not being actively worked on and is fair game for open source contributions.
+In the [Projects panel](https://github.com/Parcels-code/parcels/projects?query=is%3Aopen), you'll see the "Parcels development" project. This is used by the core development team for project management, as well as drafting up new ideas for the codebase that aren't mature enough to be issues themselves. Everything in "backlog" is not being actively worked on and is fair game for open source contributions.
 
 ## Development
 
 ### Environment setup
 
 ```{note}
-Parcels, alongside popular projects like [Xarray](https://github.com/pydata/xarray), uses [Pixi](https://pixi.sh) to manage environments and run developer tooling. Pixi is a modern alternative to Conda and also includes other powerful tooling useful for a project like Parcels ([read more](https://github.com/OceanParcels/Parcels/issues/2205)). It is our sole development workflow - we do not offer a Conda development workflow. Give Pixi a try, you won't regret it!
+Parcels, alongside popular projects like [Xarray](https://github.com/pydata/xarray), uses [Pixi](https://pixi.sh) to manage environments and run developer tooling. Pixi is a modern alternative to Conda and also includes other powerful tooling useful for a project like Parcels ([read more](https://github.com/Parcels-code/Parcels/issues/2205)). It is our sole development workflow - we do not offer a Conda development workflow. Give Pixi a try, you won't regret it!
 ```
 
 To get started contributing to Parcels:

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -9,7 +9,7 @@ See the sections in the primary sidebar and below to explore.
 
 contributing
 Versioning Policy <policies>
-Release Notes <https://github.com/OceanParcels/Parcels/releases>
+Release Notes <https://github.com/Parcels-code/Parcels/releases>
 Parcels v4.0 Migration Guide <v4-migration>
 ```
 

--- a/docs/community/maintainer.md
+++ b/docs/community/maintainer.md
@@ -24,9 +24,9 @@
   - Approve PR and merge on green
 - Update version, DOI, and release date in `CITATION.cff` file (use [Parcels Zenodo entry](https://zenodo.org/records/14001000) as reference)
 - Check "publish to PyPI" workflow succeeded
-- Update oceanparcels.org
+- Update parcels-code.org
   - Parcels development status
   - Check feature tiles
-  - Check for broken links on oceanparcels using [this tracking issue](https://github.com/OceanParcels/oceanparcels_website/issues/85)
+  - Check for broken links on oceanparcels using [this tracking issue](https://github.com/Parcels-code/oceanparcels_website/issues/85)
 - (once package is available on conda) Re-build the Binder
 - Ask for the shared parcels environment on [Lorenz](https://github.com/IMAU-oceans/Lorenz) to be updated

--- a/docs/community/policies.md
+++ b/docs/community/policies.md
@@ -15,4 +15,4 @@ Note when conducting research we highly recommend documenting which version of P
 ## Changes in policies
 
 - In v4.0.0 of Parcels, adopted EffVer which formalises this "SemVer-like" variant we were following - and we adjusted our deprecation policy.
-- In [v3.1.0](https://docs.oceanparcels.org/en/v3.1.0/community/policies.html) of Parcels, we adopted SemVer-like versioning and deprecation policies
+- In [v3.1.0](https://docs.parcels-code.org/en/v3.1.0/community/policies.html) of Parcels, we adopted SemVer-like versioning and deprecation policies

--- a/docs/community/v4-migration.md
+++ b/docs/community/v4-migration.md
@@ -1,7 +1,7 @@
 # Parcels v4 migration guide
 
 ```{warning}
-Version 4 of Parcels is unreleased at the moment. The information in this migration guide is a work in progress, and is subject to change. If you would like to provide feedback on this migration guide (or generally on the development of v4) please [submit an issue](https://github.com/OceanParcels/Parcels/issues/new/choose).
+Version 4 of Parcels is unreleased at the moment. The information in this migration guide is a work in progress, and is subject to change. If you would like to provide feedback on this migration guide (or generally on the development of v4) please [submit an issue](https://github.com/Parcels-code/Parcels/issues/new/choose).
 ```
 
 ## Kernels

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,8 +57,8 @@ master_doc = "index"
 
 # General information about the project.
 project = "Parcels"
-copyright = f"{datetime.datetime.now().year}, The OceanParcels Team"
-author = "The OceanParcels Team"
+copyright = f"{datetime.datetime.now().year}, The Parcels Team"
+author = "The Parcels Team"
 
 linkcheck_ignore = [
     r"http://localhost:\d+/",
@@ -75,7 +75,7 @@ linkcheck_ignore = [
     r"https://www\.nodc\.noaa\.gov/",  # 2023-06-23 Site non-responsive
     r"https://mybinder\.org/",  # 2023-09-02 Site non-responsive
     r"https://ariane-code.cnrs.fr/",  # 2024-04-30 Site non-responsive
-    r"https://github.com/OceanParcels/parcels/blob/daa4b062ed8ae0b2be3d87367d6b45599d6f95db/parcels/.*",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
+    r"https://github.com/Parcels-code/parcels/blob/daa4b062ed8ae0b2be3d87367d6b45599d6f95db/parcels/.*",  # ignore GitHub anchors to blobs because of https://github.com/sphinx-doc/sphinx/issues/6779
 ]
 
 # Define the canonical URL using custom domain on Read the Docs
@@ -194,7 +194,7 @@ html_theme_options = {
         "image_dark": "logo-horo_dia.svg",
     },
     "use_edit_page_button": True,
-    "github_url": "https://github.com/OceanParcels/parcels",
+    "github_url": "https://github.com/Parcels-code/parcels",
     "icon_links": [
         {
             "name": "Conda Forge",
@@ -203,11 +203,11 @@ html_theme_options = {
             "type": "fontawesome",
         }
     ],
-    "announcement": "WARNING: This documentation is built for v4 of Parcels, which is unreleased and in active development. Use the version switcher in the bottom right to select your version of Parcels, or see <a href='https://docs.oceanparcels.org/'>stable docs</a>.",
+    "announcement": "WARNING: This documentation is built for v4 of Parcels, which is unreleased and in active development. Use the version switcher in the bottom right to select your version of Parcels, or see <a href='https://docs.parcels-code.org/'>stable docs</a>.",
 }
 
 html_context = {
-    "github_user": "OceanParcels",
+    "github_user": "Parcels-code",
     "github_repo": "parcels",
     "github_version": "main",
     "doc_path": "docs",
@@ -266,11 +266,11 @@ def linkcode_resolve(domain, info):
 
     if "-" in parcels.__version__:
         return (
-            f"https://github.com/OceanParcels/parcels/blob/main/parcels/{fn}{linespec}"
+            f"https://github.com/Parcels-code/parcels/blob/main/parcels/{fn}{linespec}"
         )
     else:
         return (
-            f"https://github.com/OceanParcels/parcels/blob/"
+            f"https://github.com/Parcels-code/parcels/blob/"
             f"{parcels.__version__}/parcels/{fn}{linespec}"
         )
 
@@ -360,8 +360,8 @@ BRANCH = (
 nbsphinx_prolog = f"""
 .. raw:: html
 
-    Run this notebook in the cloud <a href="https://mybinder.org/v2/gh/OceanParcels/Parcels/{BRANCH}?urlpath=lab/tree/docs/{{{{  env.doc2path(env.docname, base=None)  }}}}" target="_blank"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg"></a>
-    , or view it <a href="https://github.com/OceanParcels/Parcels/blob/{BRANCH}/docs/{{{{  env.doc2path(env.docname, base=None)  }}}}" target="_blank">on GitHub</a>. Notebook version corresponds with {BRANCH}.
+    Run this notebook in the cloud <a href="https://mybinder.org/v2/gh/Parcels-code/Parcels/{BRANCH}?urlpath=lab/tree/docs/{{{{  env.doc2path(env.docname, base=None)  }}}}" target="_blank"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg"></a>
+    , or view it <a href="https://github.com/Parcels-code/Parcels/blob/{BRANCH}/docs/{{{{  env.doc2path(env.docname, base=None)  }}}}" target="_blank">on GitHub</a>. Notebook version corresponds with {BRANCH}.
 
     <p style="margin-bottom: 30px"></p>
 """

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -4,7 +4,7 @@ Shown below are several documentation and tutorial Jupyter notebooks and scripts
 
 ```{note}
 The tutorials written for Parcels v3 are currently being updated for Parcels v4. Shown below are only the notebooks which have been updated.
-[Feel free to post a Discussion on GitHub](https://github.com/OceanParcels/Parcels/discussions/categories/ideas) if you feel like v4 needs a specific tutorial that wasn't in v3, or [post an issue](https://github.com/OceanParcels/Parcels/issues/new?template=01_feature.md) if you feel that the notebooks below can be improved!
+[Feel free to post a Discussion on GitHub](https://github.com/Parcels-code/Parcels/discussions/categories/ideas) if you feel like v4 needs a specific tutorial that wasn't in v3, or [post an issue](https://github.com/Parcels-code/Parcels/issues/new?template=01_feature.md) if you feel that the notebooks below can be improved!
 ```
 
 ```{nbgallery}

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ _Animation of virtual particles carried by ocean surface flow in the global ocea
 
 Here you'll find [installation instructions](installation.md), [tutorials and documentation](documentation/index.md), and the [API reference](reference.md) for Parcels. You can browse the documentation for older versions by using the version switcher in the left sidebar.
 
-If you need more help with Parcels, try the [Discussions page on GitHub](https://github.com/OceanParcels/parcels/discussions). If you think you found a bug, file an [Issue on GitHub](https://github.com/OceanParcels/parcels/issues). If you want to help improve Parcels, see the [Contributing](community/contributing.md) page.
+If you need more help with Parcels, try the [Discussions page on GitHub](https://github.com/Parcels-code/parcels/discussions). If you think you found a bug, file an [Issue on GitHub](https://github.com/Parcels-code/parcels/issues). If you want to help improve Parcels, see the [Contributing](community/contributing.md) page.
 
 ```{toctree}
 :maxdepth: 2
@@ -22,5 +22,5 @@ Installation <installation>
 Tutorials & Documentation <documentation/index>
 API reference <reference>
 Contributing, Release Notes and more <community/index>
-OceanParcels website <https://oceanparcels.org/>
+OceanParcels website <https://parcels-code.org/>
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ For some of the examples, `pytest` also needs to be installed. This can be quick
 conda activate parcels
 ```
 
-**Step 4:** Download [a zipped copy](https://docs.oceanparcels.org/en/latest/_downloads/307c382eb1813dc691e8a80d6c0098f7/parcels_tutorials.zip) of the Parcels tutorials and examples and unzip it.
+**Step 4:** Download [a zipped copy](https://docs.parcels-code.org/en/latest/_downloads/307c382eb1813dc691e8a80d6c0098f7/parcels_tutorials.zip) of the Parcels tutorials and examples and unzip it.
 
 **Step 5:** Go to the unzipped folder and run one of the examples to validate that you have a working Parcels setup:
 

--- a/docs/v4/api.md
+++ b/docs/v4/api.md
@@ -35,7 +35,7 @@ classDiagram
 Here, important things to note are:
 
 - Interpolators (which would implement the `Interpolator` protocol) are responsible for the actual interpolation of the data, and performance considerations. There will be interpolation and indexing utilities that can be made available to the interpolators, allowing for code re-use.
-  - Interpolators of the data should handle spatial periodicity and, for the case of rectilinear structured grids, without pre-computing a halo for the FieldSet and Grid ([issue](https://github.com/OceanParcels/Parcels/issues/1898)).
+  - Interpolators of the data should handle spatial periodicity and, for the case of rectilinear structured grids, without pre-computing a halo for the FieldSet and Grid ([issue](https://github.com/Parcels-code/Parcels/issues/1898)).
 
 - In the `Field` class, not all combinations of `data`, `grid`, and `interpolator` will logically make sense (e.g., a `xr.DataArray` on a `ux.Grid`, or `ux.DataArray` on a `parcels.Grid`). It's up to the `Interpolator.assert_is_compatible(Field)` to define what is and is not compatible, and raise `ValueError` / `TypeError` on incompatible data types. The `.assert_is_compatible()` method also acts as developer documentation, defining clearly for the `.interpolate()` method what assumptions it is working on. The `.assert_is_compatible()` method should be lightweight as it will be called on `Field` initialisation.
 

--- a/docs/v4/index.md
+++ b/docs/v4/index.md
@@ -12,7 +12,7 @@ The key goals of this update are
 
 The timeline for the release of Parcels v4 is not yet fixed, but we are aiming for a release of an 'alpha' version in September 2025. This v4-alpha will have support for unstructured grids and user-defined interpolation methods, but is not yet performance-optimised.
 
-Collaboration on v4 development is happening on the [Parcels v4 Project Board](https://github.com/orgs/OceanParcels/projects/5).
+Collaboration on v4 development is happening on the [Parcels v4 Project Board](https://github.com/orgs/Parcels-code/projects/5).
 
 The pages below provide further background on the development of Parcels v4. You can think of this page as a "living" document as we work towards the release of v4.
 
@@ -21,6 +21,6 @@ installation
 api
 nojit
 TODO
-Parcels v4 Project Board <https://github.com/orgs/OceanParcels/projects/5>
+Parcels v4 Project Board <https://github.com/orgs/Parcels-code/projects/5>
 Parcels v4 migration guide <../community/v4-migration>
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://oceanparcels.org/"
-repository = "https://github.com/OceanParcels/parcels"
-Tracker = "https://github.com/OceanParcels/parcels/issues"
+homepage = "https://parcels-code.org/"
+repository = "https://github.com/Parcels-code/parcels"
+Tracker = "https://github.com/Parcels-code/parcels/issues"
 
 
 [tool.setuptools]

--- a/src/parcels/_core/warnings.py
+++ b/src/parcels/_core/warnings.py
@@ -22,7 +22,7 @@ class FileWarning(UserWarning):
 
     These warnings can be related to file chunking, naming, or decoding issues.
     Chunking issues in particular may negatively impact performance
-    (see also https://docs.oceanparcels.org/en/latest/examples/documentation_MPI.html#Chunking-the-FieldSet-with-dask)
+    (see also https://docs.parcels-code.org/en/latest/examples/documentation_MPI.html#Chunking-the-FieldSet-with-dask)
     """
 
     pass

--- a/src/parcels/_datasets/__init__.py
+++ b/src/parcels/_datasets/__init__.py
@@ -9,7 +9,7 @@ This subpackage uses xarray to generate *idealised* structured and unstructured 
 
 Note that this subpackage is part of the private API for Parcels. Users should not rely directly on the functions defined within this module. Instead, if you want to generate your own datasets, copy the functions from this module into your own code.
 
-Developers, note that you should only add functions that create idealised datasets to this subpackage if they are (a) quick to generate, and (b) only use dependencies already shipped with Parcels. No data files should be added to this subpackage. Real world data files should be added to the `OceanParcels/parcels-data` repository on GitHub.
+Developers, note that you should only add functions that create idealised datasets to this subpackage if they are (a) quick to generate, and (b) only use dependencies already shipped with Parcels. No data files should be added to this subpackage. Real world data files should be added to the `Parcels-code/parcels-data` repository on GitHub.
 
 Parcels Dataset Philosophy
 -------------------------

--- a/src/parcels/_decorators.py
+++ b/src/parcels/_decorators.py
@@ -52,7 +52,7 @@ def deprecated_made_private(func: Callable) -> Callable:
     return deprecated(
         "It has moved to the internal API as it is not expected to be directly used by "
         "the end-user. If you feel that you use this code directly in your scripts, please "
-        "comment on our tracking issue at https://github.com/OceanParcels/Parcels/issues/1695.",
+        "comment on our tracking issue at https://github.com/Parcels-code/Parcels/issues/1695.",
     )(func)
 
 

--- a/src/parcels/_tutorial.py
+++ b/src/parcels/_tutorial.py
@@ -13,7 +13,7 @@ __all__ = ["download_example_dataset", "list_example_datasets"]
 # make a new release in the repo and update the DATA_REPO_TAG to the new tag
 DATA_REPO_TAG = "main"
 
-DATA_URL = f"https://github.com/OceanParcels/parcels-data/raw/{DATA_REPO_TAG}/data"
+DATA_URL = f"https://github.com/Parcels-code/parcels-data/raw/{DATA_REPO_TAG}/data"
 
 # Keys are the dataset names. Values are the filenames in the dataset folder. Note that
 # you can specify subfolders in the dataset folder putting slashes in the filename list.
@@ -26,7 +26,7 @@ DATA_URL = f"https://github.com/OceanParcels/parcels-data/raw/{DATA_REPO_TAG}/da
 # └── folder2/
 #     └── file2.nc
 #
-# See instructions at https://github.com/OceanParcels/parcels-data for adding new datasets
+# See instructions at https://github.com/Parcels-code/parcels-data for adding new datasets
 EXAMPLE_DATA_FILES: dict[str, list[str]] = {
     "MovingEddies_data": [
         "moving_eddiesP.nc",


### PR DESCRIPTION
This PR renaming OceanParcels to Parcels-code throughout the parcels repo, and also removes the last references to the backcronym (Probably A Really Computationally Efficient Lagrangian Simulator) that we don't use anymore