### PR TITLE
Adding in the Runge-Kutta 2 advection schemes

### DIFF
--- a/src/parcels/kernels/__init__.py
+++ b/src/parcels/kernels/__init__.py
@@ -1,6 +1,8 @@
 from .advection import (
     AdvectionAnalytical,
     AdvectionEE,
+    AdvectionRK2,
+    AdvectionRK2_3D,
     AdvectionRK4,
     AdvectionRK4_3D,
     AdvectionRK4_3D_CROCO,
@@ -21,6 +23,8 @@ __all__ = [  # noqa: RUF022
     # advection
     "AdvectionAnalytical",
     "AdvectionEE",
+    "AdvectionRK2",
+    "AdvectionRK2_3D",
     "AdvectionRK4_3D_CROCO",
     "AdvectionRK4_3D",
     "AdvectionRK4",

--- a/src/parcels/kernels/advection.py
+++ b/src/parcels/kernels/advection.py
@@ -9,6 +9,8 @@ from parcels._core.statuscodes import StatusCode
 __all__ = [
     "AdvectionAnalytical",
     "AdvectionEE",
+    "AdvectionRK2",
+    "AdvectionRK2_3D",
     "AdvectionRK4",
     "AdvectionRK4_3D",
     "AdvectionRK4_3D_CROCO",

--- a/src/parcels/kernels/advection.py
+++ b/src/parcels/kernels/advection.py
@@ -16,6 +16,29 @@ __all__ = [
 ]
 
 
+def AdvectionRK2(particles, fieldset):  # pragma: no cover
+    """Advection of particles using second-order Runge-Kutta integration."""
+    dt = particles.dt / np.timedelta64(1, "s")  # TODO: improve API for converting dt to seconds
+    (u1, v1) = fieldset.UV[particles]
+    lon1, lat1 = (particles.lon + u1 * 0.5 * dt, particles.lat + v1 * 0.5 * dt)
+    (u2, v2) = fieldset.UV[particles.time + 0.5 * particles.dt, particles.z, lat1, lon1, particles]
+    particles.dlon += u2 * dt
+    particles.dlat += v2 * dt
+
+
+def AdvectionRK2_3D(particles, fieldset):  # pragma: no cover
+    """Advection of particles using second-order Runge-Kutta integration including vertical velocity."""
+    dt = particles.dt / np.timedelta64(1, "s")
+    (u1, v1, w1) = fieldset.UVW[particles]
+    lon1 = particles.lon + u1 * 0.5 * dt
+    lat1 = particles.lat + v1 * 0.5 * dt
+    z1 = particles.z + w1 * 0.5 * dt
+    (u2, v2, w2) = fieldset.UVW[particles.time + 0.5 * particles.dt, z1, lat1, lon1, particles]
+    particles.dlon += u2 * dt
+    particles.dlat += v2 * dt
+    particles.dz += w2 * dt
+
+
 def AdvectionRK4(particles, fieldset):  # pragma: no cover
     """Advection of particles using fourth-order Runge-Kutta integration."""
     dt = particles.dt / np.timedelta64(1, "s")  # TODO: improve API for converting dt to seconds

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -18,6 +18,8 @@ from parcels.kernels import (
     AdvectionDiffusionEM,
     AdvectionDiffusionM1,
     AdvectionEE,
+    AdvectionRK2,
+    AdvectionRK2_3D,
     AdvectionRK4,
     AdvectionRK4_3D,
     AdvectionRK45,
@@ -26,6 +28,8 @@ from tests.utils import round_and_hash_float_array
 
 kernel = {
     "EE": AdvectionEE,
+    "RK2": AdvectionRK2,
+    "RK2_3D": AdvectionRK2_3D,
     "RK4": AdvectionRK4,
     "RK4_3D": AdvectionRK4_3D,
     "RK45": AdvectionRK45,
@@ -261,6 +265,8 @@ def test_radialrotation(npart=10):
         ("EE", 1e-2),
         ("AdvDiffEM", 1e-2),
         ("AdvDiffM1", 1e-2),
+        ("RK2", 1e-5),
+        ("RK2_3D", 1e-5),
         ("RK4", 1e-5),
         ("RK4_3D", 1e-5),
         ("RK45", 1e-4),
@@ -312,6 +318,7 @@ def test_moving_eddy(method, rtol):
     "method, rtol",
     [
         ("EE", 1e-1),
+        ("RK2", 1e-5),
         ("RK4", 1e-5),
         ("RK45", 1e-4),
     ],
@@ -356,6 +363,7 @@ def test_decaying_moving_eddy(method, rtol):
 @pytest.mark.parametrize(
     "method, rtol",
     [
+        ("RK2", 0.1),
         ("RK4", 0.1),
         ("RK45", 0.1),
     ],
@@ -396,6 +404,7 @@ def test_stommelgyre_fieldset(method, rtol, grid_type):
 @pytest.mark.parametrize(
     "method, rtol",
     [
+        ("RK2", 5e-3),
         ("RK4", 5e-3),
         ("RK45", 1e-4),
     ],


### PR DESCRIPTION
I've implemented the RK2 and RK2_3D schemes for v4. I've also added the two schemes to (some of) the unit tests, but I've not touched `test_nemo_3D_curvilinear_fieldset`.

This will solve #2314
