### PR TITLE
Make `py-triangle` a tutorial dependency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+### Description
+
+### Checklist
+
 <!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [ ] Closes #xxxx

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ output
 out-*
 *.pyc
 **/*.zarr/*
-.DS_store
+.DS_Store
 
 .vscode
 .env

--- a/pixi.toml
+++ b/pixi.toml
@@ -32,7 +32,6 @@ xgcm = { git = "https://github.com/xgcm/xgcm", rev = "master" } # TODO: Switch t
 cf_xarray = ">=0.8.6"
 cftime = ">=1.6.3"
 pooch = ">=1.8.0"
-py-triangle = ">=20250106,<20250107"
 
 [dependencies]
 parcels = { path = "." }
@@ -83,6 +82,7 @@ jupyter = "*"
 trajan = "*"
 matplotlib-base = ">=2.0.2"
 gsw = "*"
+py-triangle = "*"
 
 [feature.devtools.dependencies]
 pdbpp = "*"


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I realised that the PR with the tutorial for nested grid's accidentally added `py-triangle` as a core dependency for Parcels when (I think) it should be a tutorial dependency.

Thoughts @erikvansebille ? Do we want py-triangle to be part of the default Parcels installation?

- xref https://github.com/Parcels-code/Parcels/pull/2439

Additionally this PR wraps in a couple minor edits (to PR template and to .gitignore)