### PR TITLE
DOC: Download example datasets before doc build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,7 @@ build:
       - pixi install -e docs
     build:
       html:
+        - pixi run -e docs python ci/scripts/download-all-tutorial-datasets.py
         - pixi run -e docs sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
 sphinx:
   configuration: docs/conf.py

--- a/ci/scripts/download-all-tutorial-datasets.py
+++ b/ci/scripts/download-all-tutorial-datasets.py
@@ -1,0 +1,4 @@
+import parcels.tutorial
+
+for name in parcels.tutorial.list_datasets():
+    parcels.tutorial.open_dataset(name)


### PR DESCRIPTION
### Description

In some of the previous PRs (seen in https://github.com/Parcels-code/Parcels/pull/2584 ) the documentation build was failing. This is likely due to a time-out on the first calls to `parcels.tutorial.open_dataset(...)` which the documentation terminates.

This PR adds a small script that downloads all the datasets, so that subsequent calls in the notebook are loaded quicker.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #None
- [x] Tests added (NA)
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)
