### PR TITLE
Remove Field.{x,y,z}dim

### DIFF
--- a/src/parcels/_core/field.py
+++ b/src/parcels/_core/field.py
@@ -142,32 +142,6 @@ class Field:
         return field_repr(self)
 
     @property
-    def xdim(self):
-        if type(self.data) is xr.DataArray:
-            return self.grid.xdim
-        else:
-            raise NotImplementedError("xdim not implemented for unstructured grids")
-
-    @property
-    def ydim(self):
-        if type(self.data) is xr.DataArray:
-            return self.grid.ydim
-        else:
-            raise NotImplementedError("ydim not implemented for unstructured grids")
-
-    @property
-    def zdim(self):
-        if type(self.data) is xr.DataArray:
-            return self.grid.zdim
-        else:
-            if "nz1" in self.data.dims:
-                return self.data.sizes["nz1"]
-            elif "nz" in self.data.dims:
-                return self.data.sizes["nz"]
-            else:
-                return 0
-
-    @property
     def interp_method(self):
         return self._interp_method
 


### PR DESCRIPTION
This already exists on the grid object - it doesnt have to be on the Field object.

I think this is a left over from v3.

### Description

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None
- [x] Tests added - None needed
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)
