### PR TITLE
Adding overwrite option to ParticleFile API

### DIFF
--- a/src/parcels/_core/particlefile.py
+++ b/src/parcels/_core/particlefile.py
@@ -101,7 +101,6 @@ class ParticleFile:
 
         self._path = path  # TODO v4: Consider https://arrow.apache.org/docs/python/getstarted.html#working-with-large-data - though a significant question becomes how to partition, perhaps using a particle variable "partition"?
         self._writer: pq.ParquetWriter | None = None
-        self._tmp_path: Path | None = None
 
         if self._mode not in {None, "w"}:
             raise ValueError(f"Invalid mode value {self._mode!r}. Expected one of None or 'w'.")
@@ -182,9 +181,6 @@ class ParticleFile:
         if self._writer is not None:
             self._writer.close()
             self._writer = None
-            if self._tmp_path is not None:
-                self._tmp_path.replace(self.path)
-                self._tmp_path = None
 
 
 def _get_vars_to_write(particle: ParticleClass) -> list[Variable]:

--- a/src/parcels/_core/particlefile.py
+++ b/src/parcels/_core/particlefile.py
@@ -97,18 +97,17 @@ class ParticleFile:
             raise ValueError(f"outputdt must be positive/non-zero. Got {outputdt=!r}")
 
         self._outputdt = outputdt
-        self._mode = mode
 
         self._path = path  # TODO v4: Consider https://arrow.apache.org/docs/python/getstarted.html#working-with-large-data - though a significant question becomes how to partition, perhaps using a particle variable "partition"?
         self._writer: pq.ParquetWriter | None = None
 
-        if self._mode not in {None, "w"}:
-            raise ValueError(f"Invalid mode value {self._mode!r}. Expected one of None or 'w'.")
+        if mode not in {None, "w"}:
+            raise ValueError(f"Invalid mode value {mode!r}. Expected one of None or 'w'.")
 
         if path.exists():
-            if self._mode is None:
+            if mode is None:
                 raise ValueError(f"{path=!r} already exists. Use mode='w' or use a new path.")
-            if self._mode == "w":
+            if mode == "w":
                 path.unlink()
         if not path.parent.exists():
             raise ValueError(f"Folder location for {path=!r} does not exist. Create the folder location first.")

--- a/src/parcels/_core/particlefile.py
+++ b/src/parcels/_core/particlefile.py
@@ -159,9 +159,12 @@ class ParticleFile:
         particle_data = pset._data
 
         if self._writer is None:
-            schema = _get_schema(pclass, self.metadata, fieldset.time_interval)
             assert not self.path.exists(), "If the file exists, the writer should already be set"
-            self._writer = pq.ParquetWriter(self.path, schema, compression=self._compression)
+            self._writer = pq.ParquetWriter(
+                self.path,
+                _get_schema(pclass, self.metadata, fieldset.time_interval),
+                compression=self._compression,
+            )
 
         if isinstance(time, (np.timedelta64, np.datetime64)):
             time = timedelta_to_float(time - fieldset.time_interval.left)

--- a/src/parcels/_core/particlefile.py
+++ b/src/parcels/_core/particlefile.py
@@ -61,6 +61,11 @@ class ParticleFile:
         It is either a numpy.timedelta64, a datimetime.timedelta object or a positive float (in seconds).
     compression : {"zstd", "gzip", "snappy", "brotli", None}, optional
         Compression algorithm to use for the Parquet file. Default is "zstd".
+    if_exists : {"error", "overwrite", "append"}, optional
+        Behavior when the output file already exists.
+        - "error" (default): raise a ValueError.
+        - "overwrite": remove the existing file before writing.
+        - "append": preserve existing rows and append new rows.
 
     Returns
     -------
@@ -69,7 +74,11 @@ class ParticleFile:
     """
 
     def __init__(
-        self, path: PathLike, outputdt, compression: Literal["zstd", "gzip", "snappy", "brotli", None] = "zstd"
+        self,
+        path: PathLike,
+        outputdt,
+        compression: Literal["zstd", "gzip", "snappy", "brotli", None] = "zstd",
+        if_exists: Literal["error", "overwrite", "append"] = "error",
     ):
         if not isinstance(outputdt, (np.timedelta64, timedelta, float)):
             raise ValueError(
@@ -89,12 +98,24 @@ class ParticleFile:
             raise ValueError(f"outputdt must be positive/non-zero. Got {outputdt=!r}")
 
         self._outputdt = outputdt
+        self._if_exists = if_exists
 
         self._path = path  # TODO v4: Consider https://arrow.apache.org/docs/python/getstarted.html#working-with-large-data - though a significant question becomes how to partition, perhaps using a particle variable "partition"?
         self._writer: pq.ParquetWriter | None = None
+        self._tmp_path: Path | None = None
+
+        if self._if_exists not in {"error", "overwrite", "append"}:
+            raise ValueError(
+                f"Invalid if_exists value {self._if_exists!r}. Expected one of 'error', 'overwrite', or 'append'."
+            )
+
         if path.exists():
-            # TODO: Add logic for recovering/appending to existing parquet file
-            raise ValueError(f"{path=!r} already exists. Either delete this file or use a path that doesn't exist.")
+            if self._if_exists == "error":
+                raise ValueError(
+                    f"{path=!r} already exists. Use if_exists='overwrite' or if_exists='append', or use a new path."
+                )
+            if self._if_exists == "overwrite":
+                path.unlink()
         if not path.parent.exists():
             raise ValueError(f"Folder location for {path=!r} does not exist. Create the folder location first.")
 
@@ -143,12 +164,42 @@ class ParticleFile:
         particle_data = pset._data
 
         if self._writer is None:
-            assert not self.path.exists(), "If the file exists, the writer should already be set"
-            self._writer = pq.ParquetWriter(
-                self.path,
-                _get_schema(pclass, self.metadata, fieldset.time_interval),
-                compression=self._compression,
-            )
+            schema = _get_schema(pclass, self.metadata, fieldset.time_interval)
+
+            if self._if_exists == "append" and self.path.exists():
+                existing_file = pq.ParquetFile(self.path)
+                existing_schema = existing_file.schema_arrow
+
+                if schema.names != existing_schema.names:
+                    raise ValueError(
+                        "Cannot append to existing parquet file because schema columns do not match the new output schema. "
+                        f"Existing={existing_schema.names}, new={schema.names}."
+                    )
+
+                for field_name in schema.names:
+                    if schema.field(field_name).type != existing_schema.field(field_name).type:
+                        raise ValueError(
+                            "Cannot append to existing parquet file because schema field types do not match. "
+                            f"Field {field_name!r}: existing={existing_schema.field(field_name).type}, "
+                            f"new={schema.field(field_name).type}."
+                        )
+
+                self._tmp_path = self.path.with_name(f"{self.path.stem}.append_tmp{self.path.suffix}")
+                if self._tmp_path.exists():
+                    self._tmp_path.unlink()
+
+                self._writer = pq.ParquetWriter(self._tmp_path, existing_schema, compression=self._compression)
+
+                # Parquet can't directly append, so we need to rewrite the existing data along with the new data.
+                for batch in existing_file.iter_batches():
+                    self._writer.write_table(pa.Table.from_batches([batch], schema=existing_schema))
+            else:
+                assert not self.path.exists(), "If the file exists, the writer should already be set"
+                self._writer = pq.ParquetWriter(
+                    self.path,
+                    schema,
+                    compression=self._compression,
+                )
 
         if isinstance(time, (np.timedelta64, np.datetime64)):
             time = timedelta_to_float(time - fieldset.time_interval.left)
@@ -166,6 +217,9 @@ class ParticleFile:
         if self._writer is not None:
             self._writer.close()
             self._writer = None
+            if self._tmp_path is not None:
+                self._tmp_path.replace(self.path)
+                self._tmp_path = None
 
 
 def _get_vars_to_write(particle: ParticleClass) -> list[Variable]:

--- a/src/parcels/_core/particlefile.py
+++ b/src/parcels/_core/particlefile.py
@@ -143,6 +143,42 @@ class ParticleFile:
     def path(self):
         return self._path
 
+    def _initialize_writer(self, schema: pa.Schema):
+        if self._if_exists == "append" and self.path.exists():
+            existing_file = pq.ParquetFile(self.path)
+            existing_schema = existing_file.schema_arrow
+
+            if schema.names != existing_schema.names:
+                raise ValueError(
+                    "Cannot append to existing parquet file because schema columns do not match the new output schema. "
+                    f"Existing={existing_schema.names}, new={schema.names}."
+                )
+
+            for field_name in schema.names:
+                if schema.field(field_name).type != existing_schema.field(field_name).type:
+                    raise ValueError(
+                        "Cannot append to existing parquet file because schema field types do not match. "
+                        f"Field {field_name!r}: existing={existing_schema.field(field_name).type}, "
+                        f"new={schema.field(field_name).type}."
+                    )
+
+            self._tmp_path = self.path.with_name(f"{self.path.stem}.append_tmp{self.path.suffix}")
+            if self._tmp_path.exists():
+                self._tmp_path.unlink()
+
+            self._writer = pq.ParquetWriter(self._tmp_path, existing_schema, compression=self._compression)
+
+            # Parquet can't directly append, so we need to rewrite the existing data along with the new data.
+            for batch in existing_file.iter_batches():
+                self._writer.write_table(pa.Table.from_batches([batch], schema=existing_schema))
+        else:
+            assert not self.path.exists(), "If the file exists, the writer should already be set"
+            self._writer = pq.ParquetWriter(
+                self.path,
+                schema,
+                compression=self._compression,
+            )
+
     def write(self, pset: ParticleSet | ParticleSetView, time, fieldset=None, indices=None):
         """Write all data from one time step to the zarr file,
         before the particle locations are updated.
@@ -165,41 +201,7 @@ class ParticleFile:
 
         if self._writer is None:
             schema = _get_schema(pclass, self.metadata, fieldset.time_interval)
-
-            if self._if_exists == "append" and self.path.exists():
-                existing_file = pq.ParquetFile(self.path)
-                existing_schema = existing_file.schema_arrow
-
-                if schema.names != existing_schema.names:
-                    raise ValueError(
-                        "Cannot append to existing parquet file because schema columns do not match the new output schema. "
-                        f"Existing={existing_schema.names}, new={schema.names}."
-                    )
-
-                for field_name in schema.names:
-                    if schema.field(field_name).type != existing_schema.field(field_name).type:
-                        raise ValueError(
-                            "Cannot append to existing parquet file because schema field types do not match. "
-                            f"Field {field_name!r}: existing={existing_schema.field(field_name).type}, "
-                            f"new={schema.field(field_name).type}."
-                        )
-
-                self._tmp_path = self.path.with_name(f"{self.path.stem}.append_tmp{self.path.suffix}")
-                if self._tmp_path.exists():
-                    self._tmp_path.unlink()
-
-                self._writer = pq.ParquetWriter(self._tmp_path, existing_schema, compression=self._compression)
-
-                # Parquet can't directly append, so we need to rewrite the existing data along with the new data.
-                for batch in existing_file.iter_batches():
-                    self._writer.write_table(pa.Table.from_batches([batch], schema=existing_schema))
-            else:
-                assert not self.path.exists(), "If the file exists, the writer should already be set"
-                self._writer = pq.ParquetWriter(
-                    self.path,
-                    schema,
-                    compression=self._compression,
-                )
+            self._initialize_writer(schema)
 
         if isinstance(time, (np.timedelta64, np.datetime64)):
             time = timedelta_to_float(time - fieldset.time_interval.left)

--- a/src/parcels/_core/particlefile.py
+++ b/src/parcels/_core/particlefile.py
@@ -61,11 +61,10 @@ class ParticleFile:
         It is either a numpy.timedelta64, a datimetime.timedelta object or a positive float (in seconds).
     compression : {"zstd", "gzip", "snappy", "brotli", None}, optional
         Compression algorithm to use for the Parquet file. Default is "zstd".
-    if_exists : {"error", "overwrite", "append"}, optional
-        Behavior when the output file already exists.
-        - "error" (default): raise a ValueError.
-        - "overwrite": remove the existing file before writing.
-        - "append": preserve existing rows and append new rows.
+    mode : {None, "w"}, optional
+        Writing behaviour.
+        - None (default): Write dataset, and raise an error if it already exists.
+        - "w": Write dataset, overwriting it.
 
     Returns
     -------
@@ -78,7 +77,7 @@ class ParticleFile:
         path: PathLike,
         outputdt,
         compression: Literal["zstd", "gzip", "snappy", "brotli", None] = "zstd",
-        if_exists: Literal["error", "overwrite", "append"] = "error",
+        mode: Literal[None, "w"] = None,
     ):
         if not isinstance(outputdt, (np.timedelta64, timedelta, float)):
             raise ValueError(
@@ -98,23 +97,19 @@ class ParticleFile:
             raise ValueError(f"outputdt must be positive/non-zero. Got {outputdt=!r}")
 
         self._outputdt = outputdt
-        self._if_exists = if_exists
+        self._mode = mode
 
         self._path = path  # TODO v4: Consider https://arrow.apache.org/docs/python/getstarted.html#working-with-large-data - though a significant question becomes how to partition, perhaps using a particle variable "partition"?
         self._writer: pq.ParquetWriter | None = None
         self._tmp_path: Path | None = None
 
-        if self._if_exists not in {"error", "overwrite", "append"}:
-            raise ValueError(
-                f"Invalid if_exists value {self._if_exists!r}. Expected one of 'error', 'overwrite', or 'append'."
-            )
+        if self._mode not in {None, "w"}:
+            raise ValueError(f"Invalid mode value {self._mode!r}. Expected one of None or 'w'.")
 
         if path.exists():
-            if self._if_exists == "error":
-                raise ValueError(
-                    f"{path=!r} already exists. Use if_exists='overwrite' or if_exists='append', or use a new path."
-                )
-            if self._if_exists == "overwrite":
+            if self._mode is None:
+                raise ValueError(f"{path=!r} already exists. Use mode='w' or use a new path.")
+            if self._mode == "w":
                 path.unlink()
         if not path.parent.exists():
             raise ValueError(f"Folder location for {path=!r} does not exist. Create the folder location first.")
@@ -143,42 +138,6 @@ class ParticleFile:
     def path(self):
         return self._path
 
-    def _initialize_writer(self, schema: pa.Schema):
-        if self._if_exists == "append" and self.path.exists():
-            existing_file = pq.ParquetFile(self.path)
-            existing_schema = existing_file.schema_arrow
-
-            if schema.names != existing_schema.names:
-                raise ValueError(
-                    "Cannot append to existing parquet file because schema columns do not match the new output schema. "
-                    f"Existing={existing_schema.names}, new={schema.names}."
-                )
-
-            for field_name in schema.names:
-                if schema.field(field_name).type != existing_schema.field(field_name).type:
-                    raise ValueError(
-                        "Cannot append to existing parquet file because schema field types do not match. "
-                        f"Field {field_name!r}: existing={existing_schema.field(field_name).type}, "
-                        f"new={schema.field(field_name).type}."
-                    )
-
-            self._tmp_path = self.path.with_name(f"{self.path.stem}.append_tmp{self.path.suffix}")
-            if self._tmp_path.exists():
-                self._tmp_path.unlink()
-
-            self._writer = pq.ParquetWriter(self._tmp_path, existing_schema, compression=self._compression)
-
-            # Parquet can't directly append, so we need to rewrite the existing data along with the new data.
-            for batch in existing_file.iter_batches():
-                self._writer.write_table(pa.Table.from_batches([batch], schema=existing_schema))
-        else:
-            assert not self.path.exists(), "If the file exists, the writer should already be set"
-            self._writer = pq.ParquetWriter(
-                self.path,
-                schema,
-                compression=self._compression,
-            )
-
     def write(self, pset: ParticleSet | ParticleSetView, time, fieldset=None, indices=None):
         """Write all data from one time step to the zarr file,
         before the particle locations are updated.
@@ -201,7 +160,8 @@ class ParticleFile:
 
         if self._writer is None:
             schema = _get_schema(pclass, self.metadata, fieldset.time_interval)
-            self._initialize_writer(schema)
+            assert not self.path.exists(), "If the file exists, the writer should already be set"
+            self._writer = pq.ParquetWriter(self.path, schema, compression=self._compression)
 
         if isinstance(time, (np.timedelta64, np.datetime64)):
             time = timedelta_to_float(time - fieldset.time_interval.left)

--- a/src/parcels/_core/particleset.py
+++ b/src/parcels/_core/particleset.py
@@ -429,7 +429,8 @@ class ParticleSet:
         next_output = None
         if output_file:
             # Write the initial condition
-            output_file.write(self, start_time)
+            if output_file._if_exists != "append":
+                output_file.write(self, start_time)
             # Increment the next_output
             next_output = start_time + outputdt * sign_dt
 

--- a/src/parcels/_core/particleset.py
+++ b/src/parcels/_core/particleset.py
@@ -429,8 +429,7 @@ class ParticleSet:
         next_output = None
         if output_file:
             # Write the initial condition
-            if output_file._if_exists != "append":
-                output_file.write(self, start_time)
+            output_file.write(self, start_time)
             # Increment the next_output
             next_output = start_time + outputdt * sign_dt
 

--- a/tests/test_particlefile.py
+++ b/tests/test_particlefile.py
@@ -418,28 +418,22 @@ def test_particlefile_init_existing_path_modes(fieldset, tmp_parquet):
     first_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"))
     pset.execute(DoNothing, runtime=np.timedelta64(10, "s"), dt=np.timedelta64(1, "s"), output_file=first_file)
 
+    df_first = pd.read_parquet(tmp_parquet)
+
     with pytest.raises(ValueError, match="already exists"):
         ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"))
 
-    append_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), if_exists="append")
-    pset.execute(DoNothing, runtime=np.timedelta64(10, "s"), dt=np.timedelta64(1, "s"), output_file=append_file)
-
-    df_append = pd.read_parquet(tmp_parquet)
-    np.testing.assert_equal(df_append["time"].tolist(), list(range(0, 21, 1)))
-
-    overwrite_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), if_exists="overwrite")
+    overwrite_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), mode="w")
     pset.execute(DoNothing, runtime=np.timedelta64(10, "s"), dt=np.timedelta64(1, "s"), output_file=overwrite_file)
 
     df_overwrite = pd.read_parquet(tmp_parquet)
 
-    assert (
-        len(df_append) == 2 * len(df_overwrite) - 1
-    )  # because the first time step of second run is the same as the last time step of the first run
+    assert len(df_first) == len(df_overwrite)
 
 
-def test_particlefile_init_invalid_if_exists(tmp_parquet):
-    with pytest.raises(ValueError, match="Invalid if_exists value"):
-        ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), if_exists="something-else")
+def test_particlefile_init_invalid_mode(tmp_parquet):
+    with pytest.raises(ValueError, match="Invalid mode value"):
+        ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), mode="something-else")
 
 
 @pytest.mark.parametrize("name", ["path", "outputdt"])

--- a/tests/test_particlefile.py
+++ b/tests/test_particlefile.py
@@ -416,21 +416,25 @@ def test_particlefile_init_existing_path_modes(fieldset, tmp_parquet):
     pset = ParticleSet(fieldset, pclass=Particle, lon=0, lat=0)
 
     first_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"))
-    pset.execute(DoNothing, runtime=np.timedelta64(1, "s"), dt=np.timedelta64(1, "s"), output_file=first_file)
+    pset.execute(DoNothing, runtime=np.timedelta64(10, "s"), dt=np.timedelta64(1, "s"), output_file=first_file)
 
     with pytest.raises(ValueError, match="already exists"):
         ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"))
 
+    append_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), if_exists="append")
+    pset.execute(DoNothing, runtime=np.timedelta64(10, "s"), dt=np.timedelta64(1, "s"), output_file=append_file)
+
+    df_append = pd.read_parquet(tmp_parquet)
+    np.testing.assert_equal(df_append["time"].tolist(), list(range(0, 21, 1)))
+
     overwrite_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), if_exists="overwrite")
-    pset.execute(DoNothing, runtime=np.timedelta64(1, "s"), dt=np.timedelta64(1, "s"), output_file=overwrite_file)
+    pset.execute(DoNothing, runtime=np.timedelta64(10, "s"), dt=np.timedelta64(1, "s"), output_file=overwrite_file)
 
     df_overwrite = pd.read_parquet(tmp_parquet)
 
-    append_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), if_exists="append")
-    pset.execute(DoNothing, runtime=np.timedelta64(1, "s"), dt=np.timedelta64(1, "s"), output_file=append_file)
-
-    df_append = pd.read_parquet(tmp_parquet)
-    assert len(df_append) == 2 * len(df_overwrite)
+    assert (
+        len(df_append) == 2 * len(df_overwrite) - 1
+    )  # because the first time step of second run is the same as the last time step of the first run
 
 
 def test_particlefile_init_invalid_if_exists(tmp_parquet):

--- a/tests/test_particlefile.py
+++ b/tests/test_particlefile.py
@@ -412,6 +412,32 @@ def test_particlefile_init(tmp_parquet):
     ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"))
 
 
+def test_particlefile_init_existing_path_modes(fieldset, tmp_parquet):
+    pset = ParticleSet(fieldset, pclass=Particle, lon=0, lat=0)
+
+    first_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"))
+    pset.execute(DoNothing, runtime=np.timedelta64(1, "s"), dt=np.timedelta64(1, "s"), output_file=first_file)
+
+    with pytest.raises(ValueError, match="already exists"):
+        ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"))
+
+    overwrite_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), if_exists="overwrite")
+    pset.execute(DoNothing, runtime=np.timedelta64(1, "s"), dt=np.timedelta64(1, "s"), output_file=overwrite_file)
+
+    df_overwrite = pd.read_parquet(tmp_parquet)
+
+    append_file = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), if_exists="append")
+    pset.execute(DoNothing, runtime=np.timedelta64(1, "s"), dt=np.timedelta64(1, "s"), output_file=append_file)
+
+    df_append = pd.read_parquet(tmp_parquet)
+    assert len(df_append) == 2 * len(df_overwrite)
+
+
+def test_particlefile_init_invalid_if_exists(tmp_parquet):
+    with pytest.raises(ValueError, match="Invalid if_exists value"):
+        ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"), if_exists="something-else")
+
+
 @pytest.mark.parametrize("name", ["path", "outputdt"])
 def test_particlefile_readonly_attrs(tmp_parquet, name):
     pfile = ParticleFile(tmp_parquet, outputdt=np.timedelta64(1, "s"))


### PR DESCRIPTION
### Description

This PR adds an option to `ParticleFile.__init__` to control when the file already exists: either raise an error (default), or overwrite the exisiting file. 

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2583
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt):
I used Claude code to help with the implementation of the append option in particlefile.write()