### PR TITLE
Make sure the ProgressBar also works for negative dt

### DIFF
--- a/src/parcels/_core/particleset.py
+++ b/src/parcels/_core/particleset.py
@@ -418,7 +418,7 @@ class ParticleSet:
 
         if verbose_progress:
             pbar = tqdm(
-                total=end_time - start_time,
+                total=sign_dt * (end_time - start_time),
                 file=sys.stdout,
                 bar_format="{desc} {percentage:3.0f}%|{bar}| [{elapsed}<{remaining}, {rate_fmt}]",
             )
@@ -454,7 +454,7 @@ class ParticleSet:
                 pbar.set_description_str(
                     "Integration time: " + str(float_to_datelike(time, self.fieldset.time_interval))
                 )
-                pbar.update(next_time - time)
+                pbar.update(sign_dt * (next_time - time))
 
             time = next_time
 


### PR DESCRIPTION
### Description

This PR fixes an issue where the progressbar didn't update correctly when `dt < 0`.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2658
- [ ] Tests added - Not sure how to test this; as it's the progress bar that users experience
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt):
