### PR TITLE
Renaming vector_interp_method to interp_method

### DIFF
--- a/docs/user_guide/examples/explanation_kernelloop.md
+++ b/docs/user_guide/examples/explanation_kernelloop.md
@@ -83,7 +83,7 @@ windvector = parcels.VectorField(
     "Wind",
     fieldset.UWind,
     fieldset.VWind,
-    vector_interp_method=parcels.interpolators.XLinear_Velocity
+    interp_method=parcels.interpolators.XLinear_Velocity
 )
 fieldset.add_field(windvector)
 ```

--- a/docs/user_guide/examples/tutorial_fesom.ipynb
+++ b/docs/user_guide/examples/tutorial_fesom.ipynb
@@ -149,9 +149,9 @@
     "fieldset = parcels.FieldSet.from_ugrid_conventions(ds, mesh=\"spherical\")\n",
     "\n",
     "for name, field in fieldset.fields.items():\n",
-    "    interp = getattr(field, \"interp_method\", None)\n",
-    "    interp_name = interp.__name__ if interp is not None else \"-\"\n",
-    "    print(f\"{name:>4s}  ->  {type(field).__name__:<11s}  interp={interp_name}\")"
+    "    print(\n",
+    "        f\"{name:>4s}  ->  {type(field).__name__:<11s}  interp={field.interp_method.__name__}\"\n",
+    "    )"
    ]
   },
   {
@@ -164,7 +164,11 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Release particles and advect\n\nWe seed particles on a grid of four latitudes spanning the channel and ten longitudes, and integrate for two days with RK4. Because this snapshot has only a single time level, `fieldset.time_interval` is `None` and we omit the `time=` argument so that Parcels treats the flow as constant in time:"
+   "source": [
+    "## Release particles and advect\n",
+    "\n",
+    "We seed particles on a grid of four latitudes spanning the channel and ten longitudes, and integrate for two days with RK4. Because this snapshot has only a single time level, `fieldset.time_interval` is `None` and we omit the `time=` argument so that Parcels treats the flow as constant in time:"
+   ]
   },
   {
    "cell_type": "code",
@@ -204,7 +208,11 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Plot the velocity field and trajectories\n\nWe plot the particle paths on top of the velocity field they advect through: triangle colour shows the speed at the release depth (≈50 m), black arrows show the velocity at face centres (drawn in lon/lat space, length proportional to speed), grey lines trace each particle's path, and the coloured dots mark the positions over time. Drawing the arrows with `angles=\"xy\"` keeps them aligned with the trajectories, so you can see the particles streak along the fast jets and barely move in the quiet bands between them:"
+   "source": [
+    "## Plot the velocity field and trajectories\n",
+    "\n",
+    "We plot the particle paths on top of the velocity field they advect through: triangle colour shows the speed at the release depth (≈50 m), black arrows show the velocity at face centres (drawn in lon/lat space, length proportional to speed), grey lines trace each particle's path, and the coloured dots mark the positions over time. Drawing the arrows with `angles=\"xy\"` keeps them aligned with the trajectories, so you can see the particles streak along the fast jets and barely move in the quiet bands between them:"
+   ]
   },
   {
    "cell_type": "code",
@@ -286,7 +294,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "docs",
+   "display_name": "Parcels:docs (3.14.4)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/user_guide/examples/tutorial_schism.ipynb
+++ b/docs/user_guide/examples/tutorial_schism.ipynb
@@ -216,9 +216,8 @@
     "fieldset = parcels.FieldSet.from_ugrid_conventions(uxds, mesh=\"flat\")\n",
     "\n",
     "for name, field in fieldset.fields.items():\n",
-    "    interp = getattr(field, \"interp_method\", None)\n",
     "    print(\n",
-    "        f\"{name:>4s} -> {type(field).__name__:<11s} interp={interp.__name__ if interp else '-'}\"\n",
+    "        f\"{name:>4s} -> {type(field).__name__:<11s} interp={field.interp_method.__name__}\"\n",
     "    )\n",
     "print(\"time interval:\", fieldset.time_interval)"
    ]

--- a/src/parcels/_core/field.py
+++ b/src/parcels/_core/field.py
@@ -219,10 +219,10 @@ class VectorField:
         U: Field,  # noqa: N803
         V: Field,  # noqa: N803
         W: Field | None = None,  # noqa: N803
-        vector_interp_method: Callable | None = None,
+        interp_method: Callable | None = None,
     ):
-        if vector_interp_method is None:
-            raise ValueError("vector_interp_method must be provided for VectorField initialization.")
+        if interp_method is None:
+            raise ValueError("interp_method must be provided for VectorField initialization.")
 
         _assert_str_and_python_varname(name)
         self.name = name
@@ -244,20 +244,20 @@ class VectorField:
         else:
             self.vector_type = "2D"
 
-        assert_same_function_signature(vector_interp_method, ref=ZeroInterpolator_Vector, context="Interpolation")
-        self._vector_interp_method = vector_interp_method
+        assert_same_function_signature(interp_method, ref=ZeroInterpolator_Vector, context="Interpolation")
+        self._interp_method = interp_method
 
     def __repr__(self):
         return vectorfield_repr(self)
 
     @property
-    def vector_interp_method(self):
-        return self._vector_interp_method
+    def interp_method(self):
+        return self._interp_method
 
-    @vector_interp_method.setter
-    def vector_interp_method(self, method: Callable):
+    @interp_method.setter
+    def interp_method(self, method: Callable):
         assert_same_function_signature(method, ref=ZeroInterpolator_Vector, context="Interpolation")
-        self._vector_interp_method = method
+        self._interp_method = method
 
     def eval(self, time: datetime, z, y, x, particles=None):
         """Interpolate vectorfield values in space and time.
@@ -295,7 +295,7 @@ class VectorField:
 
         particle_positions, grid_positions = _get_positions(self.U, time, z, y, x, particles, _ei)
 
-        (u, v, w) = self._vector_interp_method(particle_positions, grid_positions, self)
+        (u, v, w) = self._interp_method(particle_positions, grid_positions, self)
 
         for vel in (u, v, w):
             _update_particle_states_interp_value(particles, vel)

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -305,16 +305,14 @@ class FieldSet:
 
         fields = {}
         if "U" in ds.data_vars and "V" in ds.data_vars:
-            vector_interp_method = XLinear_Velocity if _is_agrid(ds) else CGrid_Velocity
+            interp_method = XLinear_Velocity if _is_agrid(ds) else CGrid_Velocity
             fields["U"] = Field("U", ds["U"], grid, XLinear)
             fields["V"] = Field("V", ds["V"], grid, XLinear)
-            fields["UV"] = VectorField("UV", fields["U"], fields["V"], interp_method=vector_interp_method)
+            fields["UV"] = VectorField("UV", fields["U"], fields["V"], interp_method=interp_method)
 
             if "W" in ds.data_vars:
                 fields["W"] = Field("W", ds["W"], grid, XLinear)
-                fields["UVW"] = VectorField(
-                    "UVW", fields["U"], fields["V"], fields["W"], interp_method=vector_interp_method
-                )
+                fields["UVW"] = VectorField("UVW", fields["U"], fields["V"], fields["W"], interp_method=interp_method)
 
         for varname in set(ds.data_vars) - set(fields.keys()) - skip_vars:
             fields[varname] = Field(str(varname), ds[varname], grid, XLinear)

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -214,13 +214,11 @@ class FieldSet:
         if "U" in ds.data_vars and "V" in ds.data_vars:
             fields["U"] = Field("U", ds["U"], grid, _select_uxinterpolator(ds["U"]))
             fields["V"] = Field("V", ds["V"], grid, _select_uxinterpolator(ds["V"]))
-            fields["UV"] = VectorField("UV", fields["U"], fields["V"], vector_interp_method=Ux_Velocity)
+            fields["UV"] = VectorField("UV", fields["U"], fields["V"], interp_method=Ux_Velocity)
 
             if "W" in ds.data_vars:
                 fields["W"] = Field("W", ds["W"], grid, _select_uxinterpolator(ds["W"]))
-                fields["UVW"] = VectorField(
-                    "UVW", fields["U"], fields["V"], fields["W"], vector_interp_method=Ux_Velocity
-                )
+                fields["UVW"] = VectorField("UVW", fields["U"], fields["V"], fields["W"], interp_method=Ux_Velocity)
 
         for varname in set(ds.data_vars) - set(fields.keys()):
             fields[varname] = Field(str(varname), ds[varname], grid, _select_uxinterpolator(ds[varname]))
@@ -310,12 +308,12 @@ class FieldSet:
             vector_interp_method = XLinear_Velocity if _is_agrid(ds) else CGrid_Velocity
             fields["U"] = Field("U", ds["U"], grid, XLinear)
             fields["V"] = Field("V", ds["V"], grid, XLinear)
-            fields["UV"] = VectorField("UV", fields["U"], fields["V"], vector_interp_method=vector_interp_method)
+            fields["UV"] = VectorField("UV", fields["U"], fields["V"], interp_method=vector_interp_method)
 
             if "W" in ds.data_vars:
                 fields["W"] = Field("W", ds["W"], grid, XLinear)
                 fields["UVW"] = VectorField(
-                    "UVW", fields["U"], fields["V"], fields["W"], vector_interp_method=vector_interp_method
+                    "UVW", fields["U"], fields["V"], fields["W"], interp_method=vector_interp_method
                 )
 
         for varname in set(ds.data_vars) - set(fields.keys()) - skip_vars:

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -57,7 +57,7 @@ def vectorfield_repr(vector_field: VectorField, from_fieldset_repr=False) -> str
     out = f"""<{type(vector_field).__name__} {vector_field.name!r}>
     Parcels attributes:
         name                  : {vector_field.name!r}
-        vector_interp_method  : {vector_field.vector_interp_method!r}
+        interp_method         : {vector_field.interp_method!r}
         vector_type           : {vector_field.vector_type!r}
     {field_repr(vector_field.U, level=1) if not from_fieldset_repr else ""}
     {field_repr(vector_field.V, level=1) if not from_fieldset_repr else ""}

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -191,7 +191,7 @@ def test_vectorfield_invalid_interpolator():
             name="UV",
             U=U,
             V=V,
-            vector_interp_method=invalid_interpolator_wrong_signature,
+            interp_method=invalid_interpolator_wrong_signature,
         )
 
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -139,7 +139,7 @@ def test_spatial_slip_interpolation(field, func, t, z, y, x, expected):
     field.data[:, :, 1:3, 1:3] = 0.0  # Set zero land value to test spatial slip
     U = field
     V = field
-    UV = VectorField("UV", U, V, vector_interp_method=func)
+    UV = VectorField("UV", U, V, interp_method=func)
 
     velocities = UV[t, z, y, x]
     np.testing.assert_array_almost_equal(velocities, expected)

--- a/tests/test_particleset_execute.py
+++ b/tests/test_particleset_execute.py
@@ -490,7 +490,7 @@ def test_uxstommelgyre_pset_execute():
         grid=grid,
         interp_method=UxConstantFaceConstantZC,
     )
-    UV = VectorField(name="UV", U=U, V=V, vector_interp_method=Ux_Velocity)
+    UV = VectorField(name="UV", U=U, V=V, interp_method=Ux_Velocity)
     fieldset = FieldSet([UV, UV.U, UV.V, P])
     pset = ParticleSet(
         fieldset,
@@ -536,7 +536,7 @@ def test_uxstommelgyre_multiparticle_pset_execute():
         grid=grid,
         interp_method=UxConstantFaceConstantZC,
     )
-    UVW = VectorField(name="UVW", U=U, V=V, W=W, vector_interp_method=Ux_Velocity)
+    UVW = VectorField(name="UVW", U=U, V=V, W=W, interp_method=Ux_Velocity)
     fieldset = FieldSet([UVW, UVW.U, UVW.V, UVW.W, P])
     pset = ParticleSet(
         fieldset,
@@ -575,7 +575,7 @@ def test_uxstommelgyre_pset_execute_output():
         grid=grid,
         interp_method=UxConstantFaceConstantZC,
     )
-    UV = VectorField(name="UV", U=U, V=V, vector_interp_method=Ux_Velocity)
+    UV = VectorField(name="UV", U=U, V=V, interp_method=Ux_Velocity)
     fieldset = FieldSet([UV, UV.U, UV.V, P])
     pset = ParticleSet(
         fieldset,

--- a/tests/test_uxarray_fieldset.py
+++ b/tests/test_uxarray_fieldset.py
@@ -56,7 +56,7 @@ def uv_fesom_channel(ds_fesom_channel) -> VectorField:
             grid=UxGrid(ds_fesom_channel.uxgrid, z=ds_fesom_channel.coords["zc"], mesh="flat"),
             interp_method=UxConstantFaceConstantZC,
         ),
-        vector_interp_method=Ux_Velocity,
+        interp_method=Ux_Velocity,
     )
     return UV
 
@@ -83,7 +83,7 @@ def uvw_fesom_channel(ds_fesom_channel) -> VectorField:
             grid=UxGrid(ds_fesom_channel.uxgrid, z=ds_fesom_channel.coords["zf"], mesh="flat"),
             interp_method=UxLinearNodeLinearZF,
         ),
-        vector_interp_method=Ux_Velocity,
+        interp_method=Ux_Velocity,
     )
     return UVW
 
@@ -130,7 +130,7 @@ def test_fesom2_square_delaunay_uniform_z_coordinate_eval():
         U=Field(name="U", data=ds.U, grid=grid, interp_method=UxConstantFaceConstantZC),
         V=Field(name="V", data=ds.V, grid=grid, interp_method=UxConstantFaceConstantZC),
         W=Field(name="W", data=ds.W, grid=grid, interp_method=UxLinearNodeLinearZF),
-        vector_interp_method=Ux_Velocity,
+        interp_method=Ux_Velocity,
     )
     P = Field(name="p", data=ds.p, grid=grid, interp_method=UxLinearNodeLinearZF)
     fieldset = FieldSet([UVW, P, UVW.U, UVW.V, UVW.W])


### PR DESCRIPTION
### Description

As discussed in https://github.com/Parcels-code/Parcels/pull/2660#pullrequestreview-4492787299, having an attribute `interp_method` on `Fields` but `vector_interp_method` on `VectorFields` makes for some complicated logic when users want to e.g. list all their interpolation methods.

Therefore, this PR renames `vector_interp_method` to `interp_method` throughout

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt):
