### PR TITLE
Fixing OutOfBounds errors on field.eval

### DIFF
--- a/src/parcels/_core/index_search.py
+++ b/src/parcels/_core/index_search.py
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
     from parcels._core.xgrid import XGrid
 
 
-GRID_SEARCH_ERROR = -3
-LEFT_OUT_OF_BOUNDS = -2
-RIGHT_OUT_OF_BOUNDS = -1
+GRID_SEARCH_ERROR = np.iinfo(np.int32).max - 3
+LEFT_OUT_OF_BOUNDS = np.iinfo(np.int32).max - 2
+RIGHT_OUT_OF_BOUNDS = np.iinfo(np.int32).max - 1
 
 
 def _search_1d_array(

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -5,6 +5,7 @@ import pytest
 
 from parcels import Field, UxGrid, VectorField, XGrid
 from parcels._core.fieldset import FieldSet
+from parcels._datasets.structured.generated import simple_UV_dataset
 from parcels._datasets.structured.generic import T as T_structured
 from parcels._datasets.structured.generic import datasets as datasets_structured
 from parcels._datasets.unstructured.generic import datasets as datasets_unstructured
@@ -268,6 +269,21 @@ def test_field_constant_in_time():
         x=[30.0],
     )
     assert np.isclose(P1, P2)
+
+
+def test_field_eval_out_of_bounds():
+    """Test that Field.eval returns IndexError when queried outside the grid boundaries."""
+    ds = simple_UV_dataset(mesh="flat")
+    fieldset = FieldSet.from_sgrid_conventions(ds, mesh="flat")
+
+    with pytest.raises(IndexError, match=".* is out of bounds.*"):
+        fieldset.U.eval(0.0, 0.0, 0.0, 5e6)
+
+    with pytest.raises(IndexError, match=".* is out of bounds.*"):
+        fieldset.U.eval(0.0, 0.0, 5e6, 0.0)
+
+    with pytest.raises(IndexError, match=".* is out of bounds.*"):
+        fieldset.U.eval(0.0, 5e6, 0.0, 0.0)
 
 
 def test_field_unstructured_grid_creation(): ...


### PR DESCRIPTION
### Description

In the previous implementation, the `GRID_SEARCH_ERROR`, `LEFT_OUT_OF_BOUNDS` and `RIGHT_OUT_OF_BOUNDS` were negative values, but this could create confusion when a user would call a `field.eval()` directly. Instead, these constants are now set to very large values

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2629
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt):
