### PR TITLE
Add `open_raw_zarr` helper

### DIFF
--- a/src/parcels/__init__.py
+++ b/src/parcels/__init__.py
@@ -10,6 +10,7 @@ except Exception:
 import warnings as _stdlib_warnings
 
 from parcels._core.fieldset import FieldSet
+from parcels._xarray import open_raw_zarr
 from parcels._core.particleset import ParticleSet
 from parcels._core.particlefile import ParticleFile, read_particlefile
 from parcels._core.particle import (
@@ -42,6 +43,7 @@ from parcels._logger import logger
 __all__ = [  # noqa: RUF022
     # Core classes
     "FieldSet",
+    "open_raw_zarr",
     "ParticleSet",
     "ParticleFile",
     "Variable",

--- a/src/parcels/_xarray.py
+++ b/src/parcels/_xarray.py
@@ -14,26 +14,21 @@ def open_raw_zarr(store: Store):
     """Open a Zarr dataset in an Xarray dataset, bypassing Dask."""
     with xr.open_zarr(store) as ds:
         var_to_dims = {name: var.dims for name, var in ds.variables.items()}
-        coord_names = list(ds.coords)
+        var_to_attrs = {name: var.attrs for name, var in ds.variables.items()}
+        coords = {name: ds[name].variable.load() for name in ds.coords}
+        ds_attrs = ds.attrs
 
     group = zarr.open(store, mode="r")
     assert isinstance(group, zarr.Group)
 
     data_vars = {}
-    coords = {}
     for name, array in group.members():
         if not isinstance(array, zarr.Array):
             raise ValueError("Discovered a zarr.Group in the root group. open_raw_zarr doesn't work with nested groups")
-        is_coord = name in coord_names
+        if name in coords:
+            continue
 
-        if not is_coord:
-            array.__array_function__ = _not_implemented  # trick xarray to prevent coersion to a numpy array
+        array.__array_function__ = _not_implemented  # trick xarray to prevent coersion to a numpy array
+        data_vars[name] = xr.Variable(var_to_dims[name], array, attrs=var_to_attrs[name])
 
-        var = xr.Variable(var_to_dims[name], array)
-
-        if is_coord:
-            coords[name] = var
-        else:  # name is a data var
-            data_vars[name] = var
-
-    return xr.Dataset(data_vars, coords)
+    return xr.Dataset(data_vars, coords, attrs=ds_attrs)

--- a/src/parcels/_xarray.py
+++ b/src/parcels/_xarray.py
@@ -28,7 +28,8 @@ def open_raw_zarr(store: Store):
         if name in coords:
             continue
 
-        array.__array_function__ = _not_implemented  # trick xarray to prevent coersion to a numpy array
+        # trick xarray to prevent coersion to a numpy array
+        array.__array_function__ = _not_implemented  # type: ignore[attr-defined]
         data_vars[name] = xr.Variable(var_to_dims[name], array, attrs=var_to_attrs[name])
 
     return xr.Dataset(data_vars, coords, attrs=ds_attrs)

--- a/src/parcels/_xarray.py
+++ b/src/parcels/_xarray.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import xarray as xr
+import zarr
+import zarr.storage
+from zarr.abc.store import Store
+
+
+def _not_implemented(*args, **kwargs):
+    raise NotImplementedError("This function it not implemented")
+
+
+def open_raw_zarr(store: Store):
+    """Open a Zarr dataset in an Xarray dataset, bypassing Dask."""
+    with xr.open_zarr(store) as ds:
+        var_to_dims = {name: var.dims for name, var in ds.variables.items()}
+        coord_names = list(ds.coords)
+
+    group = zarr.open(store, mode="r")
+    assert isinstance(group, zarr.Group)
+
+    data_vars = {}
+    coords = {}
+    for name, array in group.members():
+        if not isinstance(array, zarr.Array):
+            raise ValueError("Discovered a zarr.Group in the root group. open_raw_zarr doesn't work with nested groups")
+        is_coord = name in coord_names
+
+        if not is_coord:
+            array.__array_function__ = _not_implemented  # trick xarray to prevent coersion to a numpy array
+
+        var = xr.Variable(var_to_dims[name], array)
+
+        if is_coord:
+            coords[name] = var
+        else:  # name is a data var
+            data_vars[name] = var
+
+    return xr.Dataset(data_vars, coords)

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -1,0 +1,15 @@
+import pytest
+import xarray as xr
+
+from parcels import open_raw_zarr
+from parcels._datasets.structured.generic import datasets
+
+
+@pytest.mark.parametrize("ds", [pytest.param(v, id=k) for k, v in datasets.items()])
+def test_open_raw_zarr_roundtrip(ds, tmp_path):
+    path = tmp_path / "ds.zarr"
+    ds.to_zarr(path)
+
+    result = open_raw_zarr(path)
+
+    xr.testing.assert_identical(result.load(), ds)

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -1,15 +1,20 @@
 import pytest
 import xarray as xr
+import zarr
 
 from parcels import open_raw_zarr
 from parcels._datasets.structured.generic import datasets
 
 
 @pytest.mark.parametrize("ds", [pytest.param(v, id=k) for k, v in datasets.items()])
-def test_open_raw_zarr_roundtrip(ds, tmp_path):
+def test_open_raw_zarr(ds, tmp_path):
     path = tmp_path / "ds.zarr"
     ds.to_zarr(path)
 
     result = open_raw_zarr(path)
+
+    for k in result.data_vars:
+        # tests that the internal representation within Xarray isn't coerced into a numpy array
+        assert isinstance(result[k]._variable._data, zarr.Array)
 
     xr.testing.assert_identical(result.load(), ds)


### PR DESCRIPTION
### Description

This helper ingests a Zarr dataset into an Xarray dataset by bypassing Dask.

xref https://github.com/pydata/xarray/discussions/11236#discussioncomment-17266708

PR is (somewhat) blocked by #2646 - at least #2646 greatly simplifies the number of Xarray objects we have flying around.


### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt): Just got it to right the test, and fix the code based on that
