### PR TITLE
Consolidate ptype to pclass attribute names #2184

### DIFF
--- a/docs/user_guide/examples_v3/tutorial_peninsula_AvsCgrid.ipynb
+++ b/docs/user_guide/examples_v3/tutorial_peninsula_AvsCgrid.ipynb
@@ -19,6 +19,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from dataclasses import dataclass\n",
     "from typing import Literal\n",
@@ -101,7 +108,7 @@
     "        particle.delete()\n",
     "\n",
     "\n",
-    "ptype = parcels.Particle.add_variables({\"p\": np.float32})"
+    "pclass = parcels.Particle.add_variables({\"p\": np.float32})"
    ]
   },
   {
@@ -167,7 +174,7 @@
     "    )\n",
     "\n",
     "    pset = parcels.ParticleSet.from_line(\n",
-    "        fieldset, pclass=ptype, size=7, start=(1e3, 1e3), finish=(1e3, 10e3)\n",
+    "        fieldset, pclass=pclass, size=7, start=(1e3, 1e3), finish=(1e3, 10e3)\n",
     "    )\n",
     "    outfile = pset.ParticleFile(name=exp.file_name, outputdt=dt)\n",
     "\n",

--- a/src/parcels/_core/kernel.py
+++ b/src/parcels/_core/kernel.py
@@ -47,8 +47,8 @@ class Kernel:
         list of Kernel functions
     fieldset : parcels.Fieldset
         FieldSet object providing the field information (possibly None)
-    ptype :
-        PType object for the kernel particle
+    pclass :
+        pclass object for the kernel particle
 
     Notes
     -----
@@ -73,7 +73,7 @@ class Kernel:
             raise ValueError("List of `kernels` should have at least one function.")
 
         self._fieldset = pset.fieldset
-        self._ptype = pset._ptype
+        self._pclass = pset._pclass
 
         for f in kernels:
             self.check_fieldsets_in_kernels(f)
@@ -88,8 +88,8 @@ class Kernel:
         return ret
 
     @property
-    def ptype(self):
-        return self._ptype
+    def pclass(self):
+        return self._pclass
 
     @property
     def fieldset(self):
@@ -132,7 +132,7 @@ class Kernel:
                 if self._fieldset.U.grid._gtype not in [GridType.CurvilinearZGrid, GridType.RectilinearZGrid]:
                     raise NotImplementedError("Analytical Advection only works with Z-grids in the vertical")
             elif kernel is AdvectionRK45:
-                if "next_dt" not in [v.name for v in self.ptype.variables]:
+                if "next_dt" not in [v.name for v in self.pclass.variables]:
                     raise ValueError('ParticleClass requires a "next_dt" for AdvectionRK45 Kernel.')
                 if not hasattr(self.fieldset, "RK45_tol"):
                     warnings.warn(
@@ -165,12 +165,12 @@ class Kernel:
             raise TypeError(f"Cannot merge {type(kernel)} with {type(self)}. Both should be of type {type(self)}.")
 
         assert self.fieldset == kernel.fieldset, "Cannot merge kernels with different fieldsets"
-        assert self.ptype == kernel.ptype, "Cannot merge kernels with different particle types"
+        assert self.pclass == kernel.pclass, "Cannot merge kernels with different particle types"
 
         return type(self)(
             self._kernels + kernel._kernels,
             self.fieldset,
-            self.ptype,
+            self.pclass,
         )
 
     def execute(self, pset, endtime, dt):

--- a/src/parcels/_core/particlefile.py
+++ b/src/parcels/_core/particlefile.py
@@ -149,7 +149,7 @@ class ParticleFile:
         fieldset :
             FieldSet object associated with the ParticleSet (optional). By default, the fieldset associated with the ParticleSet will be used, but this can be overridden by providing a fieldset here. This is used in cases when the particleset is a ParticleSetView.
         """
-        pclass = pset._ptype
+        pclass = pset._pclass
         if isinstance(pset, ParticleSetView) and fieldset is None:
             raise ValueError("When writing a ParticleSetView, a fieldset must be provided to the write() method.")
         if fieldset is None:

--- a/src/parcels/_core/particleset.py
+++ b/src/parcels/_core/particleset.py
@@ -119,7 +119,7 @@ class ParticleSet:
                 particle_id=particle_ids,
             ),
         )
-        self._ptype = pclass
+        self._pclass = pclass
 
         # update initial values provided on ParticleSet creation # TODO: Wrap this into create_particle_data
         particle_variables = [v.name for v in pclass.variables]
@@ -159,7 +159,7 @@ class ParticleSet:
 
     def __getitem__(self, index):
         """Get a single particle by index."""
-        return ParticleSetView(self._data, index=index, ptype=self._ptype)
+        return ParticleSetView(self._data, index=index, pclass=self._pclass)
 
     def __setattr__(self, name, value):
         if name in ["_data"]:

--- a/src/parcels/_core/particlesetview.py
+++ b/src/parcels/_core/particlesetview.py
@@ -6,10 +6,10 @@ from parcels._reprs import particlesetview_repr
 class ParticleSetView:
     """Class to be used in a kernel that links a View of the ParticleSet (on the kernel level) to a ParticleSet."""
 
-    def __init__(self, data, index, ptype):
+    def __init__(self, data, index, pclass):
         self._data = data
         self._index = index
-        self._ptype = ptype
+        self._pclass = pclass
 
     def __getattr__(self, name):
         # Return a proxy that behaves like the underlying numpy array but
@@ -28,7 +28,7 @@ class ParticleSetView:
         return self._data[name][self._index]
 
     def __setattr__(self, name, value):
-        if name in ["_data", "_index", "_ptype"]:
+        if name in ["_data", "_index", "_pclass"]:
             object.__setattr__(self, name, value)
         else:
             self._data[name][self._index] = value
@@ -56,7 +56,7 @@ class ParticleSetView:
                 raise ValueError(
                     f"Boolean index has incompatible length {arr.size} for selection of size {int(np.sum(base))}"
                 )
-            return ParticleSetView(self._data, new_index, self._ptype)
+            return ParticleSetView(self._data, new_index, self._pclass)
 
         # Integer array/list, slice or single integer relative to the local view
         # (boolean masks were handled above). Normalize and map to global
@@ -71,12 +71,12 @@ class ParticleSetView:
                 base_arr = np.asarray(base)
                 sel = base_arr[idx]
             new_index[sel] = True
-            return ParticleSetView(self._data, new_index, self._ptype)
+            return ParticleSetView(self._data, new_index, self._pclass)
 
         # Fallback: try to assign directly (preserves previous behaviour for other index types)
         try:
             new_index[base] = index
-            return ParticleSetView(self._data, new_index, self._ptype)
+            return ParticleSetView(self._data, new_index, self._pclass)
         except Exception as e:
             raise TypeError(f"Unsupported index type for ParticleSetView.__getitem__: {type(index)!r}") from e
 

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -89,7 +89,7 @@ def particleset_repr(pset: ParticleSet) -> str:
     Particles:
 {_format_list_items_multiline(particles, level=2, with_brackets=False)}
     Pclass:
-{textwrap.indent(repr(pset._ptype), 8 * " ")}
+{textwrap.indent(repr(pset._pclass), 8 * " ")}
 """
     return textwrap.dedent(out).strip()
 
@@ -98,7 +98,7 @@ def particlesetview_repr(pview: Any) -> str:
     """Return a pretty repr for ParticleSetView"""
     time_string = "not_yet_set" if pview.time is None or np.isnan(pview.time) else f"{pview.time:f}"
     out = f"P[{pview.particle_id}]: time={time_string}, z={pview.z:f}, lat={pview.lat:f}, lon={pview.lon:f}"
-    vars = [v.name for v in pview._ptype.variables if v.to_write is True and v.name not in ["lon", "lat", "z", "time"]]
+    vars = [v.name for v in pview._pclass.variables if v.to_write is True and v.name not in ["lon", "lat", "z", "time"]]
     for var in vars:
         out += f", {var}={getattr(pview, var):f}"
 

--- a/tests-v3/test_kernel_language.py
+++ b/tests-v3/test_kernel_language.py
@@ -18,7 +18,7 @@ from tests.utils import create_fieldset_unit_mesh
 def expr_kernel(name, pset, expr):
     pycode = (f"def {name}(particle, fieldset, time):\n"
               f"    particle.p = {expr}")  # fmt: skip
-    return Kernel(kernels=None, fieldset=pset.fieldset, ptype=pset._ptype, funccode=pycode, funcname=name)
+    return Kernel(kernels=None, fieldset=pset.fieldset, pclass=pset._pclass, funccode=pycode, funcname=name)
 
 
 @pytest.fixture

--- a/tests-v3/test_particlesets.py
+++ b/tests-v3/test_particlesets.py
@@ -166,7 +166,7 @@ def test_pset_access(fieldset):
     assert np.allclose([pset[i].lat for i in range(pset.size)], lat, rtol=1e-12)
 
 
-def test_pset_custom_ptype(fieldset):
+def test_pset_custom_pclass(fieldset):
     npart = 100
     TestParticle = Particle.add_variable([Variable("p", np.float32, initial=0.33), Variable("n", np.int32, initial=2)])
 


### PR DESCRIPTION
This pull request consolidates pclass attribute name throughout the codebase by changing all the previous ptype and _ptype attribute names into pclass and _pclass respectively.

- [x] Closes #2184
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)