### PR TITLE
Remove `.add_context` limitation on numeric types

### DIFF
--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -177,8 +177,6 @@ class FieldSet:
 
         if name in self.context:
             raise ValueError(f"FieldSet already has a context with name '{name}'")
-        if not isinstance(value, (float, np.floating, int, np.integer)):
-            raise ValueError(f"FieldSet context variables have to be of type float or int, got a {type(value)}")
         self.context[name] = value
 
     @property

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -19,6 +19,33 @@ def test_unknown_var_in_kernel(fieldset):
         pset.execute(ErrorKernel, runtime=np.timedelta64(2, "s"), dt=np.timedelta64(1, "s"))
 
 
+def test_context_in_kernel(fieldset):
+    pset = ParticleSet(fieldset, lon=[0.5], lat=[0.5])
+
+    fieldset.add_context("fix_lon", -0.5)
+
+    def ContextKernel(particles, fieldset):
+        particles.lon = fieldset.fix_lon
+
+    pset.execute(ContextKernel, runtime=np.timedelta64(2, "s"), dt=np.timedelta64(1, "s"))
+    assert pset.lon == -0.5
+
+
+def test_func_context_in_kernel(fieldset):
+    pset = ParticleSet(fieldset, lon=[0.5], lat=[0.5])
+
+    def ContextFunc(x):
+        return 2 * x
+
+    fieldset.add_context("func", ContextFunc)
+
+    def FuncContextKernel(particles, fieldset):
+        particles.lon = fieldset.func(particles.lon)
+
+    pset.execute(FuncContextKernel, runtime=np.timedelta64(2, "s"), dt=np.timedelta64(1, "s"))
+    assert pset.lon == 2.0
+
+
 def test_kernel_init(fieldset):
     pset = ParticleSet(fieldset, lon=[0.5], lat=[0.5])
     Kernel(kernels=[AdvectionRK4], pset=pset)


### PR DESCRIPTION
### Description

Removed error raised if context type != float.
Added tests for context accessed from kernels.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2675
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt):
