### PR TITLE
Speeding up test_mitgcm

### DIFF
--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -473,18 +473,17 @@ def test_mitgcm():
     lat = np.linspace(22e3, 1950e3, npart)
 
     pset = parcels.ParticleSet(fieldset, lon=lon, lat=lat)
-    pset.execute(AdvectionRK4, runtime=np.timedelta64(5, "D"), dt=np.timedelta64(30, "m"))
-
-    lon_v3 = [
-        25334.3084714,
-        82824.04760837,
-        136410.63322281,
-        98325.83708985,
-        83152.54325753,
-        89321.35275493,
-        237376.5840757,
-        56860.97672692,
-        153947.52685014,
-        28349.16658616,
+    pset.execute(AdvectionRK4, runtime=np.timedelta64(1, "D"), dt=np.timedelta64(1, "h"))
+    lat_v3 = [
+        22363.3109351,
+        241677.27730161,
+        461322.50669352,
+        664760.42373974,
+        886760.91201257,
+        1087116.48719691,
+        1274515.29539529,
+        1542216.3950654,
+        1741733.45906654,
+        1952691.93845841,
     ]
-    np.testing.assert_allclose(pset.lon, lon_v3, atol=10)
+    np.testing.assert_allclose(pset.lat, lat_v3, atol=1)


### PR DESCRIPTION
This PR addresses #2689, by shortening the runtime of `test_mitgcm()`. The unit test duration drops from >30 seconds to ~3 seconds; and the total test suite from 89s to 65s.

### Description

Note that I also had to redo the test_mitgcm in v3; and that I initially didn't get equivalent results because I forgot that the `pset.lat` of v4 should be compared to the `pset.lat_nextloop` of v3!

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2689 
- [x] Tests updated
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt):
