### PR TITLE
MAINT: Add `docs-clean` Pixi task 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,6 @@ build:
     build:
       html:
         - pixi run -e docs python ci/scripts/download-all-tutorial-datasets.py
-        - pixi run -e docs sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
+        - SPHINXOPTS='-T' BUILDDIR=$READTHEDOCS_OUTPUT/html pixi run docs-clean
 sphinx:
   configuration: docs/conf.py

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -51,6 +51,7 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf .jupyter_cache
+	rm -f */**/*.parquet
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -53,7 +53,7 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf .jupyter_cache
-	rm -f **/*.parquet
+	find . -name "*.parquet" -delete
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+SPHINXATUOBUILD = sphinx-autobuild
 PAPER         =
 BUILDDIR      = _build
 
@@ -24,6 +25,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  livehtml   to make HTML files and serve with rebuilding on a server"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -51,7 +53,7 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf .jupyter_cache
-	rm -f */**/*.parquet
+	rm -f **/*.parquet
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
@@ -192,3 +194,7 @@ pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+
+livehtml:
+	@echo "$(SPHINXATUOBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html"
+	$(SPHINXATUOBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/pixi.toml
+++ b/pixi.toml
@@ -128,9 +128,10 @@ sphinx-design = "*"
 sphinx-autoapi = "*"
 
 [feature.docs.tasks]
-docs = { cmd = "sphinx-build docs docs/_build", description = "Build the documentation." }
-docs-watch = { cmd = "sphinx-autobuild docs docs/_build", description = "Build and auto-rebuild the documentation on changes." }
-docs-linkcheck = { cmd = "sphinx-build -b linkcheck docs/ docs/_build/linkcheck", description = "Verify all links in documentation don't 404." }
+docs = { cmd = "make html", cwd = "docs", description = "Build the documentation." }
+docs-clean = { cmd = "make clean && make html", cwd = "docs", description = "Build the documentation." }
+docs-watch = { cmd = "make livehtml", cwd = "docs", description = "Build and auto-rebuild the documentation on changes." }
+docs-linkcheck = { cmd = "make linkcheck", cwd = "docs", description = "Verify all links in documentation don't 404." }
 
 [feature.pre-commit.dependencies]
 pre_commit = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -128,8 +128,12 @@ sphinx-design = "*"
 sphinx-autoapi = "*"
 
 [feature.docs.tasks]
+docs-only-clean = { cmd = "make clean", cwd = "docs", description = "Cleans the documentation folder of build artifacts." }
 docs = { cmd = "make html", cwd = "docs", description = "Build the documentation." }
-docs-clean = { cmd = "make clean && make html", cwd = "docs", description = "Build the documentation." }
+docs-clean = { depends-on = [
+  { task = "docs-only-clean" },
+  { task = "docs" },
+], description = "Build the documentation from a clean docs folder." }
 docs-watch = { cmd = "make livehtml", cwd = "docs", description = "Build and auto-rebuild the documentation on changes." }
 docs-linkcheck = { cmd = "make linkcheck", cwd = "docs", description = "Verify all links in documentation don't 404." }
 


### PR DESCRIPTION
### Description

It would be great to clean out artifacts (e.g., generated Parquet files) from the docs folder during building.

This PR does the following:
- Adds a `docs-clean` Pixi task which first cleans the `docs` folder then builds the docs
- Adds a `docs-only-clean` which just cleans the docs folder
- Updates the Pixi tasks to use the tasks used in the makefile definition
  - It would be great if we could just remove the makefile entirely, and leverage Pixi's task running for everything, however unfortunately the Pixi task runner [isn't as flexible as we need it to be.](https://github.com/prefix-dev/pixi/issues/4208#issuecomment-4789425517)


### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None