### PR TITLE
Add tutorial_write_in_kernel to the docs page

### DIFF
--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -51,6 +51,7 @@ examples/tutorial_delaystart.ipynb
 examples/explanation_kernelloop.md
 examples/tutorial_sampling.ipynb
 examples/tutorial_statuscodes.ipynb
+examples/tutorial_write_in_kernel.ipynb
 ```
 
 ```{toctree}


### PR DESCRIPTION
### Description

While #2620 implemented the functionality to write particle sets to output inside a Kernel and provided a tutorial for it, I now realise that that tutorial was not added to the docs page, so was not easily findable there. This PR adds it

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2599 
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt):
