### PR TITLE
Add `vector_fields` parameter to FieldSet creation methods

### DIFF
--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -211,7 +211,7 @@ class FieldSet:
         cls,
         ds: ux.UxDataset,
         mesh: str = "spherical",
-        vector_fields: ptyping.VectorFields | None | NotSetType = NOTSET,
+        vector_fields: ptyping.VectorFields | NotSetType = NOTSET,
     ):
         """Create a FieldSet from a Parcels compliant uxarray.UxDataset.
 
@@ -229,8 +229,7 @@ class FieldSet:
         vector_fields : Mapping[str, tuple[str, ...]] or None, optional
             Mapping of vector field names to tuples of component variable names in the dataset.
             For example, ``{"UV": ("U", "V"), "UVW": ("U", "V", "W")}``.
-            If ``None``, no vector fields are constructed. If omitted (default), vector fields
-            are auto-discovered from standard variable names (``U``/``V``/``W``).
+            If omitted (default), vector fields are auto-discovered from standard variable names (``U``/``V``/``W``).
 
         Returns
         -------
@@ -249,7 +248,7 @@ class FieldSet:
         cls,
         ds: xr.Dataset,
         mesh: ptyping.Mesh | None = None,
-        vector_fields: ptyping.VectorFields | None | NotSetType = NOTSET,
+        vector_fields: ptyping.VectorFields | NotSetType = NOTSET,
     ):  # TODO: Update mesh to be discovered from the dataset metadata
         """Create a FieldSet from a dataset using SGRID convention metadata.
 
@@ -267,8 +266,7 @@ class FieldSet:
         vector_fields : Mapping[str, tuple[str, ...]] or None, optional
             Mapping of vector field names to tuples of component variable names in the dataset.
             For example, ``{"UV": ("U", "V"), "UVW": ("U", "V", "W")}``.
-            If ``None``, no vector fields are constructed. If omitted (default), vector fields
-            are auto-discovered from standard variable names (``U``/``V``/``W``).
+            If omitted (default), vector fields are auto-discovered from standard variable names (``U``/``V``/``W``).
 
         Returns
         -------

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -263,7 +263,7 @@ class FieldSet:
         mesh : str
             String indicating the type of mesh coordinates used during
             velocity interpolation. Options are "spherical" or "flat".
-        vector_fields : Mapping[str, tuple[str, ...]] or None, optional
+        vector_fields : Mapping[str, tuple[str, ...]], optional
             Mapping of vector field names to tuples of component variable names in the dataset.
             For example, ``{"UV": ("U", "V"), "UVW": ("U", "V", "W")}``.
             If omitted (default), vector fields are auto-discovered from standard variable names (``U``/``V``/``W``).

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -14,7 +14,7 @@ from parcels._core.model import (
     CONSTANT_FIELD_MODELS,
     ModelData,
     StructuredModelData,
-    TVectorFieldMapping,
+    TVectorField,
     UnstructuredModelData,
 )
 from parcels._core.utils.string import _assert_str_and_python_varname
@@ -212,7 +212,7 @@ class FieldSet:
         cls,
         ds: ux.UxDataset,
         mesh: str = "spherical",
-        vector_fields: TVectorFieldMapping | None | NotSetType = NOTSET,
+        vector_fields: TVectorField | None | NotSetType = NOTSET,
     ):
         """Create a FieldSet from a Parcels compliant uxarray.UxDataset.
 
@@ -250,7 +250,7 @@ class FieldSet:
         cls,
         ds: xr.Dataset,
         mesh: Mesh | None = None,
-        vector_fields: TVectorFieldMapping | None | NotSetType = NOTSET,
+        vector_fields: TVectorField | None | NotSetType = NOTSET,
     ):  # TODO: Update mesh to be discovered from the dataset metadata
         """Create a FieldSet from a dataset using SGRID convention metadata.
 

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -226,7 +226,7 @@ class FieldSet:
         ----------
         ds : uxarray.UxDataset
             uxarray.UxDataset as obtained from the uxarray package but with appropriate named vertical dimensions
-        vector_fields : Mapping[str, tuple[str, ...]] or None, optional
+        vector_fields : Mapping[str, tuple[str, ...]], optional
             Mapping of vector field names to tuples of component variable names in the dataset.
             For example, ``{"UV": ("U", "V"), "UVW": ("U", "V", "W")}``.
             If omitted (default), vector fields are auto-discovered from standard variable names (``U``/``V``/``W``).

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -20,7 +20,7 @@ from parcels._core.model import (
 from parcels._core.utils.string import _assert_str_and_python_varname
 from parcels._core.utils.time import get_datetime_type_calendar
 from parcels._core.utils.time import is_compatible as datetime_is_compatible
-from parcels._python import _MISSING, _MissingType
+from parcels._python import NOTSET, NotSetType
 from parcels._typing import Mesh
 from parcels.interpolators import (
     XConstantField,
@@ -212,7 +212,7 @@ class FieldSet:
         cls,
         ds: ux.UxDataset,
         mesh: str = "spherical",
-        vector_fields: TVectorFieldMapping | None | _MissingType = _MISSING,
+        vector_fields: TVectorFieldMapping | None | NotSetType = NOTSET,
     ):
         """Create a FieldSet from a Parcels compliant uxarray.UxDataset.
 
@@ -250,7 +250,7 @@ class FieldSet:
         cls,
         ds: xr.Dataset,
         mesh: Mesh | None = None,
-        vector_fields: TVectorFieldMapping | None | _MissingType = _MISSING,
+        vector_fields: TVectorFieldMapping | None | NotSetType = NOTSET,
     ):  # TODO: Update mesh to be discovered from the dataset metadata
         """Create a FieldSet from a dataset using SGRID convention metadata.
 

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -227,6 +227,11 @@ class FieldSet:
         ----------
         ds : uxarray.UxDataset
             uxarray.UxDataset as obtained from the uxarray package but with appropriate named vertical dimensions
+        vector_fields : Mapping[str, tuple[str, ...]] or None, optional
+            Mapping of vector field names to tuples of component variable names in the dataset.
+            For example, ``{"UV": ("U", "V"), "UVW": ("U", "V", "W")}``.
+            If ``None``, no vector fields are constructed. If omitted (default), vector fields
+            are auto-discovered from standard variable names (``U``/``V``/``W``).
 
         Returns
         -------
@@ -260,6 +265,11 @@ class FieldSet:
         mesh : str
             String indicating the type of mesh coordinates used during
             velocity interpolation. Options are "spherical" or "flat".
+        vector_fields : Mapping[str, tuple[str, ...]] or None, optional
+            Mapping of vector field names to tuples of component variable names in the dataset.
+            For example, ``{"UV": ("U", "V"), "UVW": ("U", "V", "W")}``.
+            If ``None``, no vector fields are constructed. If omitted (default), vector fields
+            are auto-discovered from standard variable names (``U``/``V``/``W``).
 
         Returns
         -------

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -9,19 +9,18 @@ import numpy as np
 import uxarray as ux
 import xarray as xr
 
+import parcels._typing as ptyping
 from parcels._core.field import Field, VectorField
 from parcels._core.model import (
     CONSTANT_FIELD_MODELS,
     ModelData,
     StructuredModelData,
-    TVectorField,
     UnstructuredModelData,
 )
 from parcels._core.utils.string import _assert_str_and_python_varname
 from parcels._core.utils.time import get_datetime_type_calendar
 from parcels._core.utils.time import is_compatible as datetime_is_compatible
 from parcels._python import NOTSET, NotSetType
-from parcels._typing import Mesh
 from parcels.interpolators import (
     XConstantField,
 )
@@ -151,7 +150,7 @@ class FieldSet:
 
         self.fields[name] = field
 
-    def add_constant_field(self, name: str, value, mesh: Mesh = "spherical"):
+    def add_constant_field(self, name: str, value, mesh: ptyping.Mesh = "spherical"):
         """Wrapper function to add a Field that is constant in space,
            useful e.g. when using constant horizontal diffusivity
 
@@ -212,7 +211,7 @@ class FieldSet:
         cls,
         ds: ux.UxDataset,
         mesh: str = "spherical",
-        vector_fields: TVectorField | None | NotSetType = NOTSET,
+        vector_fields: ptyping.VectorFields | None | NotSetType = NOTSET,
     ):
         """Create a FieldSet from a Parcels compliant uxarray.UxDataset.
 
@@ -249,8 +248,8 @@ class FieldSet:
     def from_sgrid_conventions(
         cls,
         ds: xr.Dataset,
-        mesh: Mesh | None = None,
-        vector_fields: TVectorField | None | NotSetType = NOTSET,
+        mesh: ptyping.Mesh | None = None,
+        vector_fields: ptyping.VectorFields | None | NotSetType = NOTSET,
     ):  # TODO: Update mesh to be discovered from the dataset metadata
         """Create a FieldSet from a dataset using SGRID convention metadata.
 

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -10,10 +10,17 @@ import uxarray as ux
 import xarray as xr
 
 from parcels._core.field import Field, VectorField
-from parcels._core.model import CONSTANT_FIELD_MODELS, ModelData, StructuredModelData, UnstructuredModelData
+from parcels._core.model import (
+    CONSTANT_FIELD_MODELS,
+    ModelData,
+    StructuredModelData,
+    TVectorFieldMapping,
+    UnstructuredModelData,
+)
 from parcels._core.utils.string import _assert_str_and_python_varname
 from parcels._core.utils.time import get_datetime_type_calendar
 from parcels._core.utils.time import is_compatible as datetime_is_compatible
+from parcels._python import _MISSING, _MissingType
 from parcels._typing import Mesh
 from parcels.interpolators import (
     XConstantField,
@@ -201,7 +208,12 @@ class FieldSet:
         return grids
 
     @classmethod
-    def from_ugrid_conventions(cls, ds: ux.UxDataset, mesh: str = "spherical"):
+    def from_ugrid_conventions(
+        cls,
+        ds: ux.UxDataset,
+        mesh: str = "spherical",
+        vector_fields: TVectorFieldMapping | None | _MissingType = _MISSING,
+    ):
         """Create a FieldSet from a Parcels compliant uxarray.UxDataset.
 
         This is the primary ingestion method in Parcels for structured grid datasets.
@@ -225,12 +237,15 @@ class FieldSet:
         -----
         See https://ugrid-conventions.github.io/ugrid-conventions/ for more information on the UGRID conventions.
         """
-        model = UnstructuredModelData.from_ugrid_conventions(ds, mesh)
+        model = UnstructuredModelData.from_ugrid_conventions(ds, mesh, vector_fields)
         return cls([model])
 
     @classmethod
     def from_sgrid_conventions(
-        cls, ds: xr.Dataset, mesh: Mesh | None = None
+        cls,
+        ds: xr.Dataset,
+        mesh: Mesh | None = None,
+        vector_fields: TVectorFieldMapping | None | _MissingType = _MISSING,
     ):  # TODO: Update mesh to be discovered from the dataset metadata
         """Create a FieldSet from a dataset using SGRID convention metadata.
 
@@ -259,7 +274,7 @@ class FieldSet:
 
         See https://sgrid.github.io/sgrid/ for more information on the SGRID conventions.
         """
-        model = StructuredModelData.from_sgrid_conventions(ds, mesh)
+        model = StructuredModelData.from_sgrid_conventions(ds, mesh, vector_fields)
         return cls([model])
 
 

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -371,9 +371,3 @@ _COPERNICUS_MARINE_CF_STANDARD_NAME_FALLBACKS = {
     ],
     "W": ["upward_sea_water_velocity", "vertical_sea_water_velocity"],
 }
-
-
-def _is_agrid(ds: xr.Dataset) -> bool:
-    # check if U and V are defined on the same dimensions
-    # if yes, interpret as A grid
-    return set(ds["U"].dims) == set(ds["V"].dims)

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -172,9 +172,7 @@ class StructuredModelData(ModelData):
         return model
 
 
-def resolve_vector_fields(
-    ds: xr.Dataset, vector_fields: TVectorField | None | NotSetType
-) -> TVectorField:
+def resolve_vector_fields(ds: xr.Dataset, vector_fields: TVectorField | None | NotSetType) -> TVectorField:
     if vector_fields is None:
         return {}
     if vector_fields is NOTSET:  # i.e., the default vectorfield discovery behaviour
@@ -261,9 +259,7 @@ class UnstructuredModelData(ModelData):
         return list(self.data.data_vars)
 
     @classmethod
-    def from_ugrid_conventions(
-        cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: TVectorField | None | NotSetType
-    ):
+    def from_ugrid_conventions(cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: TVectorField | None | NotSetType):
         ds_dims = list(ds.dims)
         if not all(dim in ds_dims for dim in ["time", "zf", "zc"]):
             raise ValueError(

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -19,7 +19,7 @@ from parcels._core.xgrid import (
     assert_all_field_dims_have_axis,  # noqa: F401, leave import for now until decision is made # TODO v4: Make decision
 )
 from parcels._logger import logger
-from parcels._python import _MISSING, _MissingType
+from parcels._python import NOTSET, NotSetType
 from parcels._typing import Mesh
 from parcels.convert import _ds_rename_using_standard_names
 from parcels.interpolators import (
@@ -133,7 +133,7 @@ class StructuredModelData(ModelData):
 
     @classmethod
     def from_sgrid_conventions(
-        cls, ds: xr.Dataset, mesh: Mesh | None, vector_fields: TVectorFieldMapping | None | _MissingType
+        cls, ds: xr.Dataset, mesh: Mesh | None, vector_fields: TVectorFieldMapping | None | NotSetType
     ) -> Self:
         ds = ds.copy()
         if mesh is None:
@@ -173,11 +173,11 @@ class StructuredModelData(ModelData):
 
 
 def resolve_vector_fields(
-    ds: xr.Dataset, vector_fields: TVectorFieldMapping | None | _MissingType
+    ds: xr.Dataset, vector_fields: TVectorFieldMapping | None | NotSetType
 ) -> TVectorFieldMapping:
     if vector_fields is None:
         return {}
-    if vector_fields is _MISSING:  # i.e., the default vectorfield discovery behaviour
+    if vector_fields is NOTSET:  # i.e., the default vectorfield discovery behaviour
         return _default_vector_field_components(ds.data_vars)
     return vector_fields
 
@@ -262,7 +262,7 @@ class UnstructuredModelData(ModelData):
 
     @classmethod
     def from_ugrid_conventions(
-        cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: TVectorFieldMapping | None | _MissingType
+        cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: TVectorFieldMapping | None | NotSetType
     ):
         ds_dims = list(ds.dims)
         if not all(dim in ds_dims for dim in ["time", "zf", "zc"]):

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -133,7 +133,7 @@ class StructuredModelData(ModelData):
         return list(fields.values())
 
     @classmethod
-    def from_sgrid_conventions(cls, ds: xr.Dataset, mesh: Mesh | None = None) -> Self:
+    def from_sgrid_conventions(cls, ds: xr.Dataset, mesh: Mesh | None) -> Self:
         ds = ds.copy()
         if mesh is None:
             mesh = _get_mesh_type_from_sgrid_dataset(ds)
@@ -239,7 +239,7 @@ class UnstructuredModelData(ModelData):
         return list(self.data.data_vars)
 
     @classmethod
-    def from_ugrid_conventions(cls, ds: ux.UxDataset, mesh: str = "spherical"):
+    def from_ugrid_conventions(cls, ds: ux.UxDataset, mesh: Mesh):
         ds_dims = list(ds.dims)
         if not all(dim in ds_dims for dim in ["time", "zf", "zc"]):
             raise ValueError(

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
 from typing import Any, Self
 
 import cf_xarray  # noqa: F401
@@ -18,6 +19,7 @@ from parcels._core.xgrid import (
     assert_all_field_dims_have_axis,  # noqa: F401, leave import for now until decision is made # TODO v4: Make decision
 )
 from parcels._logger import logger
+from parcels._python import _MissingType
 from parcels._typing import Mesh
 from parcels.convert import _ds_rename_using_standard_names
 from parcels.interpolators import (
@@ -32,11 +34,14 @@ from parcels.interpolators import (
 )
 from parcels.interpolators._base import ScalarInterpolator, VectorInterpolator
 
+TVectorFieldMapping = Mapping[str, tuple[str, str] | tuple[str, str, str]]
+
 
 class ModelData(ABC):
     data: Any
     grid: BaseGrid
     field_to_interpolator: dict[str, ScalarInterpolator | VectorInterpolator]
+    vector_field_components: TVectorFieldMapping
 
     @abstractmethod
     def construct_fields(self) -> list[Field | VectorField]: ...
@@ -79,7 +84,7 @@ def preprocess_sgrid_model_data(ds: xr.Dataset) -> xr.Dataset:
 
 
 class StructuredModelData(ModelData):
-    def __init__(self, data: xr.Dataset, mesh: Mesh):
+    def __init__(self, data: xr.Dataset, mesh: Mesh, vector_field_components: TVectorFieldMapping):
         if not isinstance(data, xr.Dataset):
             raise ValueError(f"Expected `data` to be an xarray.Dataset . Got {type(data)}")
 
@@ -88,6 +93,7 @@ class StructuredModelData(ModelData):
 
         self.data = data
         self.grid = grid
+        self.vector_field_components = vector_field_components
         self.field_to_interpolator = {}
         self._fields: list[Field | VectorField] | None = None
         self.assert_valid_model_data()
@@ -133,7 +139,9 @@ class StructuredModelData(ModelData):
         return list(fields.values())
 
     @classmethod
-    def from_sgrid_conventions(cls, ds: xr.Dataset, mesh: Mesh | None) -> Self:
+    def from_sgrid_conventions(
+        cls, ds: xr.Dataset, mesh: Mesh | None, vector_fields: TVectorFieldMapping | None | _MissingType
+    ) -> Self:
         ds = ds.copy()
         if mesh is None:
             mesh = _get_mesh_type_from_sgrid_dataset(ds)
@@ -160,7 +168,7 @@ class StructuredModelData(ModelData):
         #     ds["lon"] = ds[node_dimensions[0]]
         #     ds["lat"] = ds[node_dimensions[1]]
 
-        model = cls(ds, mesh=mesh)
+        model = cls(ds, mesh=mesh, vector_field_components=vector_fields)
         model._fields = model.construct_fields()
         for f in model._fields:
             if isinstance(f, Field):
@@ -191,13 +199,14 @@ CONSTANT_FIELD_MODELS = {
             ),
         ),
         mesh=mesh,  # type:ignore
+        vector_fields=None,
     )
     for mesh in ["flat", "spherical"]
 }
 
 
 class UnstructuredModelData(ModelData):
-    def __init__(self, data: ux.UxDataset, grid: UxGrid):
+    def __init__(self, data: ux.UxDataset, grid: UxGrid, vector_field_components: TVectorFieldMapping):
         if not isinstance(data, ux.UxDataset):
             raise ValueError(f"Expected `data` to be an uxarray.UxDataset . Got {type(data)}")
 
@@ -206,6 +215,7 @@ class UnstructuredModelData(ModelData):
 
         self.data = data
         self.grid = grid
+        self.vector_field_components = vector_field_components
         self.field_to_interpolator = {}
         self._fields: list[Field | VectorField] | None = None
 
@@ -239,7 +249,9 @@ class UnstructuredModelData(ModelData):
         return list(self.data.data_vars)
 
     @classmethod
-    def from_ugrid_conventions(cls, ds: ux.UxDataset, mesh: Mesh):
+    def from_ugrid_conventions(
+        cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: TVectorFieldMapping | None | _MissingType
+    ):
         ds_dims = list(ds.dims)
         if not all(dim in ds_dims for dim in ["time", "zf", "zc"]):
             raise ValueError(
@@ -274,6 +286,17 @@ def _get_mesh_type_from_sgrid_dataset(ds_sgrid: xr.Dataset) -> Mesh:
         raise ValueError(msg)
 
     return "spherical" if _is_coordinate_in_degrees(ds_sgrid[fpoint_x]) else "flat"
+
+
+def _default_vector_field_components(data_vars: Sequence[str]) -> TVectorFieldMapping:
+    vars = set(data_vars)
+    ret = {}
+
+    if {"U", "V"}.issubset(vars):
+        ret["UV"] = ("U", "V")
+    if {"U", "V", "W"}.issubset(vars):
+        ret["UVW"] = ("U", "V", "W")
+    return ret
 
 
 def _is_coordinate_in_degrees(da: xr.DataArray) -> bool:

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -132,7 +132,7 @@ class StructuredModelData(ModelData):
 
     @classmethod
     def from_sgrid_conventions(
-        cls, ds: xr.Dataset, mesh: Mesh | None, vector_fields: ptyping.VectorFields | None | NotSetType
+        cls, ds: xr.Dataset, mesh: Mesh | None, vector_fields: ptyping.VectorFields | NotSetType
     ) -> Self:
         ds = ds.copy()
         if mesh is None:
@@ -171,19 +171,15 @@ class StructuredModelData(ModelData):
         return model
 
 
-def resolve_vector_fields(
-    ds: xr.Dataset, vector_fields: ptyping.VectorFields | None | NotSetType
-) -> ptyping.VectorFields:
-    if vector_fields is None:
-        return {}
+def resolve_vector_fields(ds: xr.Dataset, vector_fields: ptyping.VectorFields | NotSetType) -> ptyping.VectorFields:
     if vector_fields is NOTSET:  # i.e., the default vectorfield discovery behaviour
         return _default_vector_field_components(list(ds.data_vars))
     return vector_fields
 
 
 def assert_valid_vector_fields(ds: xr.Dataset, vector_fields: ptyping.VectorFields) -> None:
-    # if not isinstance(vector_fields, dict):
-    #     raise ValueError(f"vector_fields must be a dictionary. Got {type(vector_fields)=!r}.")
+    if not isinstance(vector_fields, dict):
+        raise ValueError(f"vector_fields must be a dictionary. Got {type(vector_fields)=!r}.")
 
     for vfield_name, components in vector_fields.items():
         if not isinstance(vfield_name, str):
@@ -237,7 +233,7 @@ CONSTANT_FIELD_MODELS = {
             ),
         ),
         mesh=mesh,  # type:ignore
-        vector_fields=None,
+        vector_fields={},
     )
     for mesh in ["flat", "spherical"]
 }
@@ -283,9 +279,7 @@ class UnstructuredModelData(ModelData):
         return list(self.data.data_vars)
 
     @classmethod
-    def from_ugrid_conventions(
-        cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: ptyping.VectorFields | None | NotSetType
-    ):
+    def from_ugrid_conventions(cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: ptyping.VectorFields | NotSetType):
         ds_dims = list(ds.dims)
         if not all(dim in ds_dims for dim in ["time", "zf", "zc"]):
             raise ValueError(

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Hashable, Sequence
 from typing import Any, Self
 
 import cf_xarray  # noqa: F401
@@ -34,14 +34,14 @@ from parcels.interpolators import (
 )
 from parcels.interpolators._base import ScalarInterpolator, VectorInterpolator
 
-TVectorFieldMapping = Mapping[str, tuple[str, str] | tuple[str, str, str]]
+TVectorField = dict[str, tuple[str, str] | tuple[str, str, str]]
 
 
 class ModelData(ABC):
     data: Any
     grid: BaseGrid
     field_to_interpolator: dict[str, ScalarInterpolator | VectorInterpolator]
-    vector_field_components: TVectorFieldMapping
+    vector_field_components: TVectorField
 
     @abstractmethod
     def construct_fields(self) -> list[Field | VectorField]: ...
@@ -84,7 +84,7 @@ def preprocess_sgrid_model_data(ds: xr.Dataset) -> xr.Dataset:
 
 
 class StructuredModelData(ModelData):
-    def __init__(self, data: xr.Dataset, mesh: Mesh, vector_field_components: TVectorFieldMapping):
+    def __init__(self, data: xr.Dataset, mesh: Mesh, vector_field_components: TVectorField):
         if not isinstance(data, xr.Dataset):
             raise ValueError(f"Expected `data` to be an xarray.Dataset . Got {type(data)}")
 
@@ -126,14 +126,14 @@ class StructuredModelData(ModelData):
             )
 
             component_fields = [single_fields[name] for name in components]
-            vector_fields[vfield_name] = VectorField(vfield_name, *component_fields, interp_method=interp_method)
+            vector_fields[vfield_name] = VectorField(vfield_name, *component_fields, interp_method=interp_method)  # type:ignore[misc,arg-type]
 
         fields: dict[str, Field | VectorField] = {**single_fields, **vector_fields}
         return list(fields.values())
 
     @classmethod
     def from_sgrid_conventions(
-        cls, ds: xr.Dataset, mesh: Mesh | None, vector_fields: TVectorFieldMapping | None | NotSetType
+        cls, ds: xr.Dataset, mesh: Mesh | None, vector_fields: TVectorField | None | NotSetType
     ) -> Self:
         ds = ds.copy()
         if mesh is None:
@@ -173,16 +173,16 @@ class StructuredModelData(ModelData):
 
 
 def resolve_vector_fields(
-    ds: xr.Dataset, vector_fields: TVectorFieldMapping | None | NotSetType
-) -> TVectorFieldMapping:
+    ds: xr.Dataset, vector_fields: TVectorField | None | NotSetType
+) -> TVectorField:
     if vector_fields is None:
         return {}
     if vector_fields is NOTSET:  # i.e., the default vectorfield discovery behaviour
-        return _default_vector_field_components(ds.data_vars)
+        return _default_vector_field_components(list(ds.data_vars))
     return vector_fields
 
 
-def assert_vector_field_components_in_dataset(ds: xr.Dataset, vector_fields: TVectorFieldMapping) -> None:
+def assert_vector_field_components_in_dataset(ds: xr.Dataset, vector_fields: TVectorField) -> None:
     for components in vector_fields.values():
         for c in components:
             if c not in ds.data_vars:
@@ -222,7 +222,7 @@ CONSTANT_FIELD_MODELS = {
 
 
 class UnstructuredModelData(ModelData):
-    def __init__(self, data: ux.UxDataset, grid: UxGrid, vector_field_components: TVectorFieldMapping):
+    def __init__(self, data: ux.UxDataset, grid: UxGrid, vector_field_components: TVectorField):
         if not isinstance(data, ux.UxDataset):
             raise ValueError(f"Expected `data` to be an uxarray.UxDataset . Got {type(data)}")
 
@@ -247,7 +247,7 @@ class UnstructuredModelData(ModelData):
             interp_method = Ux_Velocity()
 
             component_fields = [single_fields[name] for name in components]
-            vector_fields[vfield_name] = VectorField(vfield_name, *component_fields, interp_method=interp_method)
+            vector_fields[vfield_name] = VectorField(vfield_name, *component_fields, interp_method=interp_method)  # type:ignore[misc, arg-type]
 
         fields: dict[str, Field | VectorField] = {**single_fields, **vector_fields}
         return list(fields.values())
@@ -262,7 +262,7 @@ class UnstructuredModelData(ModelData):
 
     @classmethod
     def from_ugrid_conventions(
-        cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: TVectorFieldMapping | None | NotSetType
+        cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: TVectorField | None | NotSetType
     ):
         ds_dims = list(ds.dims)
         if not all(dim in ds_dims for dim in ["time", "zf", "zc"]):
@@ -304,9 +304,9 @@ def _get_mesh_type_from_sgrid_dataset(ds_sgrid: xr.Dataset) -> Mesh:
     return "spherical" if _is_coordinate_in_degrees(ds_sgrid[fpoint_x]) else "flat"
 
 
-def _default_vector_field_components(data_vars: Sequence[str]) -> TVectorFieldMapping:
+def _default_vector_field_components(data_vars: Sequence[Hashable]) -> TVectorField:
     vars = set(data_vars)
-    ret = {}
+    ret: TVectorField = {}
 
     if {"U", "V"}.issubset(vars):
         ret["UV"] = ("U", "V")

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -9,6 +9,7 @@ import uxarray as ux
 import xarray as xr
 
 import parcels._sgrid as sgrid
+import parcels._typing as ptyping
 from parcels._core.basegrid import BaseGrid
 from parcels._core.field import Field, VectorField
 from parcels._core.utils.time import TimeInterval
@@ -34,14 +35,12 @@ from parcels.interpolators import (
 )
 from parcels.interpolators._base import ScalarInterpolator, VectorInterpolator
 
-TVectorField = dict[str, tuple[str, str] | tuple[str, str, str]]
-
 
 class ModelData(ABC):
     data: Any
     grid: BaseGrid
     field_to_interpolator: dict[str, ScalarInterpolator | VectorInterpolator]
-    vector_field_components: TVectorField
+    vector_field_components: ptyping.VectorFields
 
     @abstractmethod
     def construct_fields(self) -> list[Field | VectorField]: ...
@@ -84,7 +83,7 @@ def preprocess_sgrid_model_data(ds: xr.Dataset) -> xr.Dataset:
 
 
 class StructuredModelData(ModelData):
-    def __init__(self, data: xr.Dataset, mesh: Mesh, vector_field_components: TVectorField):
+    def __init__(self, data: xr.Dataset, mesh: Mesh, vector_field_components: ptyping.VectorFields):
         if not isinstance(data, xr.Dataset):
             raise ValueError(f"Expected `data` to be an xarray.Dataset . Got {type(data)}")
 
@@ -133,7 +132,7 @@ class StructuredModelData(ModelData):
 
     @classmethod
     def from_sgrid_conventions(
-        cls, ds: xr.Dataset, mesh: Mesh | None, vector_fields: TVectorField | None | NotSetType
+        cls, ds: xr.Dataset, mesh: Mesh | None, vector_fields: ptyping.VectorFields | None | NotSetType
     ) -> Self:
         ds = ds.copy()
         if mesh is None:
@@ -172,7 +171,9 @@ class StructuredModelData(ModelData):
         return model
 
 
-def resolve_vector_fields(ds: xr.Dataset, vector_fields: TVectorField | None | NotSetType) -> TVectorField:
+def resolve_vector_fields(
+    ds: xr.Dataset, vector_fields: ptyping.VectorFields | None | NotSetType
+) -> ptyping.VectorFields:
     if vector_fields is None:
         return {}
     if vector_fields is NOTSET:  # i.e., the default vectorfield discovery behaviour
@@ -180,7 +181,7 @@ def resolve_vector_fields(ds: xr.Dataset, vector_fields: TVectorField | None | N
     return vector_fields
 
 
-def assert_vector_field_components_in_dataset(ds: xr.Dataset, vector_fields: TVectorField) -> None:
+def assert_vector_field_components_in_dataset(ds: xr.Dataset, vector_fields: ptyping.VectorFields) -> None:
     for components in vector_fields.values():
         for c in components:
             if c not in ds.data_vars:
@@ -220,7 +221,7 @@ CONSTANT_FIELD_MODELS = {
 
 
 class UnstructuredModelData(ModelData):
-    def __init__(self, data: ux.UxDataset, grid: UxGrid, vector_field_components: TVectorField):
+    def __init__(self, data: ux.UxDataset, grid: UxGrid, vector_field_components: ptyping.VectorFields):
         if not isinstance(data, ux.UxDataset):
             raise ValueError(f"Expected `data` to be an uxarray.UxDataset . Got {type(data)}")
 
@@ -259,7 +260,9 @@ class UnstructuredModelData(ModelData):
         return list(self.data.data_vars)
 
     @classmethod
-    def from_ugrid_conventions(cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: TVectorField | None | NotSetType):
+    def from_ugrid_conventions(
+        cls, ds: ux.UxDataset, mesh: Mesh, vector_fields: ptyping.VectorFields | None | NotSetType
+    ):
         ds_dims = list(ds.dims)
         if not all(dim in ds_dims for dim in ["time", "zf", "zc"]):
             raise ValueError(
@@ -300,9 +303,9 @@ def _get_mesh_type_from_sgrid_dataset(ds_sgrid: xr.Dataset) -> Mesh:
     return "spherical" if _is_coordinate_in_degrees(ds_sgrid[fpoint_x]) else "flat"
 
 
-def _default_vector_field_components(data_vars: Sequence[Hashable]) -> TVectorField:
+def _default_vector_field_components(data_vars: Sequence[Hashable]) -> ptyping.VectorFields:
     vars = set(data_vars)
-    ret: TVectorField = {}
+    ret: ptyping.VectorFields = {}
 
     if {"U", "V"}.issubset(vars):
         ret["UV"] = ("U", "V")

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -239,21 +239,17 @@ class UnstructuredModelData(ModelData):
         single_fields: dict[str, Field] = {}
         vector_fields: dict[str, VectorField] = {}
         scalar_field_names = self.scalar_field_names
-        if "U" in scalar_field_names and "V" in scalar_field_names:
-            single_fields["U"] = Field("U", self)
-            single_fields["V"] = Field("V", self)
-            vector_fields["UV"] = VectorField("UV", single_fields["U"], single_fields["V"], interp_method=Ux_Velocity())
 
-            if "W" in scalar_field_names:
-                single_fields["W"] = Field("W", self)
-                vector_fields["UVW"] = VectorField(
-                    "UVW", single_fields["U"], single_fields["V"], single_fields["W"], interp_method=Ux_Velocity()
-                )
+        for varname in set(scalar_field_names):
+            single_fields[varname] = Field(str(varname), self)
+
+        for vfield_name, components in self.vector_field_components.items():
+            interp_method = Ux_Velocity()
+
+            component_fields = [single_fields[name] for name in components]
+            vector_fields[vfield_name] = VectorField(vfield_name, *component_fields, interp_method=interp_method)
 
         fields: dict[str, Field | VectorField] = {**single_fields, **vector_fields}
-        for varname in set(scalar_field_names) - set(single_fields.keys()):
-            fields[varname] = Field(str(varname), self)
-
         return list(fields.values())
 
     def assert_valid_field_data(self, field_data: ux.UxDataArray) -> None:
@@ -276,7 +272,11 @@ class UnstructuredModelData(ModelData):
 
         grid = UxGrid(ds.uxgrid, z=ds.coords["zf"], mesh=mesh)
         ds = _discover_ux_U_and_V(ds)
-        model = cls(ds, grid)
+
+        vector_fields = resolve_vector_fields(ds, vector_fields)
+        assert_vector_field_components_in_dataset(ds, vector_fields)
+
+        model = cls(ds, grid, vector_fields)
         model._fields = model.construct_fields()
         for f in model._fields:
             if isinstance(f, Field):

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -19,7 +19,7 @@ from parcels._core.xgrid import (
     assert_all_field_dims_have_axis,  # noqa: F401, leave import for now until decision is made # TODO v4: Make decision
 )
 from parcels._logger import logger
-from parcels._python import _MissingType
+from parcels._python import _MISSING, _MissingType
 from parcels._typing import Mesh
 from parcels.convert import _ds_rename_using_standard_names
 from parcels.interpolators import (
@@ -116,26 +116,19 @@ class StructuredModelData(ModelData):
         single_fields: dict[str, Field] = {}
         vector_fields: dict[str, VectorField] = {}
         scalar_field_names = self.scalar_field_names
-        if "U" in scalar_field_names and "V" in scalar_field_names:
-            interp_method = XLinear_Velocity() if _is_agrid(self.data) else CGrid_Velocity()
-            single_fields["U"] = Field("U", self)
-            single_fields["V"] = Field("V", self)
-            vector_fields["UV"] = VectorField("UV", single_fields["U"], single_fields["V"], interp_method=interp_method)
 
-            if "W" in scalar_field_names:
-                single_fields["W"] = Field("W", self)
-                vector_fields["UVW"] = VectorField(
-                    "UVW",
-                    single_fields["U"],
-                    single_fields["V"],
-                    single_fields["W"],
-                    interp_method=interp_method,
-                )
+        for varname in set(scalar_field_names):
+            single_fields[varname] = Field(str(varname), self)
+
+        for vfield_name, components in self.vector_field_components.items():
+            interp_method = (
+                XLinear_Velocity() if _is_agrid(self.data, u=components[0], v=components[1]) else CGrid_Velocity()
+            )
+
+            component_fields = [single_fields[name] for name in components]
+            vector_fields[vfield_name] = VectorField(vfield_name, *component_fields, interp_method=interp_method)
 
         fields: dict[str, Field | VectorField] = {**single_fields, **vector_fields}
-        for varname in set(scalar_field_names) - set(fields.keys()):
-            fields[varname] = Field(str(varname), self)
-
         return list(fields.values())
 
     @classmethod
@@ -168,12 +161,35 @@ class StructuredModelData(ModelData):
         #     ds["lon"] = ds[node_dimensions[0]]
         #     ds["lat"] = ds[node_dimensions[1]]
 
+        vector_fields = resolve_vector_fields(ds, vector_fields)
+        assert_vector_field_components_in_dataset(ds, vector_fields)
+
         model = cls(ds, mesh=mesh, vector_field_components=vector_fields)
         model._fields = model.construct_fields()
         for f in model._fields:
             if isinstance(f, Field):
                 f.interp_method = XLinear()
         return model
+
+
+def resolve_vector_fields(
+    ds: xr.Dataset, vector_fields: TVectorFieldMapping | None | _MissingType
+) -> TVectorFieldMapping:
+    if vector_fields is None:
+        return {}
+    if vector_fields is _MISSING:  # i.e., the default vectorfield discovery behaviour
+        return _default_vector_field_components(ds.data_vars)
+    return vector_fields
+
+
+def assert_vector_field_components_in_dataset(ds: xr.Dataset, vector_fields: TVectorFieldMapping) -> None:
+    for components in vector_fields.values():
+        for c in components:
+            if c not in ds.data_vars:
+                raise ValueError(
+                    f"Field component '{c}' not present in the source dataset, but is listed in {vector_fields=!r}. This component cannot be used in this mapping."
+                )
+    return
 
 
 CONSTANT_FIELD_MODELS = {
@@ -389,10 +405,10 @@ def _select_uxinterpolator(da: ux.UxDataArray):
     return None
 
 
-def _is_agrid(ds: xr.Dataset) -> bool:
+def _is_agrid(ds: xr.Dataset, u: str, v: str) -> bool:
     # check if U and V are defined on the same dimensions
     # if yes, interpret as A grid
-    return set(ds["U"].dims) == set(ds["V"].dims)
+    return set(ds[u].dims) == set(ds[v].dims)
 
 
 def _get_time_interval(data: xr.DataArray | ux.UxDataArray) -> TimeInterval | None:

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -161,7 +161,7 @@ class StructuredModelData(ModelData):
         #     ds["lat"] = ds[node_dimensions[1]]
 
         vector_fields = resolve_vector_fields(ds, vector_fields)
-        assert_vector_field_components_in_dataset(ds, vector_fields)
+        assert_valid_vector_fields(ds, vector_fields)
 
         model = cls(ds, mesh=mesh, vector_field_components=vector_fields)
         model._fields = model.construct_fields()
@@ -179,6 +179,29 @@ def resolve_vector_fields(
     if vector_fields is NOTSET:  # i.e., the default vectorfield discovery behaviour
         return _default_vector_field_components(list(ds.data_vars))
     return vector_fields
+
+
+def assert_valid_vector_fields(ds: xr.Dataset, vector_fields: ptyping.VectorFields) -> None:
+    # if not isinstance(vector_fields, dict):
+    #     raise ValueError(f"vector_fields must be a dictionary. Got {type(vector_fields)=!r}.")
+
+    for vfield_name, components in vector_fields.items():
+        if not isinstance(vfield_name, str):
+            raise ValueError(
+                f"Invalid `vector_fields` argument. Vector field name in `vector_fields` should be a string. Got field name {vfield_name!r}."
+            )
+        if not (2 <= len(components) <= 3):
+            raise ValueError(
+                f"Invalid `vector_fields` argument. Vector fields must have either 2 or 3 components. Vector field {vfield_name} has {len(components)} components."
+            )
+        for c in components:
+            if not isinstance(c, str):
+                raise ValueError(
+                    f"Invalid `vector_fields` argument. Component names must be strings. Got component name of value {c!r}."
+                )
+
+    assert_vector_field_components_in_dataset(ds, vector_fields)
+    return
 
 
 def assert_vector_field_components_in_dataset(ds: xr.Dataset, vector_fields: ptyping.VectorFields) -> None:
@@ -273,7 +296,7 @@ class UnstructuredModelData(ModelData):
         ds = _discover_ux_U_and_V(ds)
 
         vector_fields = resolve_vector_fields(ds, vector_fields)
-        assert_vector_field_components_in_dataset(ds, vector_fields)
+        assert_valid_vector_fields(ds, vector_fields)
 
         model = cls(ds, grid, vector_fields)
         model._fields = model.construct_fields()

--- a/src/parcels/_python.py
+++ b/src/parcels/_python.py
@@ -1,10 +1,14 @@
 # Generic Python helpers
+import enum
 import inspect
 from collections.abc import Callable, Mapping
 from typing import TypeVar
 
 K = TypeVar("K")
 V = TypeVar("V")
+
+_MissingType = enum.Enum("_MissingType", "VALUE")
+_MISSING = _MissingType.VALUE
 
 
 def isinstance_noimport(obj, class_or_tuple):

--- a/src/parcels/_python.py
+++ b/src/parcels/_python.py
@@ -7,8 +7,8 @@ from typing import TypeVar
 K = TypeVar("K")
 V = TypeVar("V")
 
-_MissingType = enum.Enum("_MissingType", "VALUE")
-_MISSING = _MissingType.VALUE
+NotSetType = enum.Enum("NotSetType", "VALUE")
+NOTSET = NotSetType.VALUE
 
 
 def isinstance_noimport(obj, class_or_tuple):

--- a/src/parcels/_typing.py
+++ b/src/parcels/_typing.py
@@ -47,6 +47,7 @@ XgcmAxisDirection = CfAxisSpatial | Literal["T"]
 CfAxis = XgcmAxisDirection
 XgcmAxisPosition = Literal["center", "left", "right", "inner", "outer"]
 XgcmAxes = Mapping[XgcmAxisDirection, "xgcm.Axis"]
+VectorFields = dict[str, tuple[str, str] | tuple[str, str, str]]
 
 
 def _is_xarray_object(obj):  # with no imports

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -12,6 +12,7 @@ from parcels._datasets.structured.generic import T as T_structured
 from parcels._datasets.structured.generic import datasets as datasets_structured
 from parcels._datasets.unstructured.generic import _ux_constant_flow_face_centered_2D
 from parcels._datasets.unstructured.generic import datasets as datasets_unstructured
+from parcels._python import NOTSET
 from parcels.interpolators import (
     UxConstantFaceConstantZC,
 )
@@ -19,7 +20,7 @@ from parcels.interpolators import (
 
 def test_field_init_param_types():
     data = datasets_structured["ds_2d_left"]
-    model = StructuredModelData.from_sgrid_conventions(data, mesh="flat")
+    model = StructuredModelData.from_sgrid_conventions(data, mesh="flat", vector_fields=NOTSET)
 
     with pytest.raises(TypeError, match="Expected a string for variable name, got int instead."):
         Field(name=123, model=model)
@@ -52,7 +53,7 @@ def test_field_init_fail_on_float_time_dim():
         ds["time"].attrs,
     )
 
-    model = StructuredModelData.from_sgrid_conventions(ds, mesh="flat")
+    model = StructuredModelData.from_sgrid_conventions(ds, mesh="flat", vector_fields=NOTSET)
     with pytest.raises(
         ValueError,
         match=r"Are you sure that the time dimension on the xarray dataset is stored as timedelta, datetime or cftime datetime objects\?",
@@ -64,7 +65,7 @@ def test_field_init_fail_on_float_time_dim():
 def test_field_time_interval():
     """Test that field.time_interval delegates correctly to model.time_interval."""
     data = datasets_structured["ds_2d_left"]
-    model = StructuredModelData.from_sgrid_conventions(data, mesh="flat")
+    model = StructuredModelData.from_sgrid_conventions(data, mesh="flat", vector_fields=NOTSET)
     field = Field(name="data_g", model=model)
     assert field.time_interval.left == np.datetime64("2000-01-01")
     assert field.time_interval.right == np.datetime64("2001-01-01")
@@ -77,7 +78,7 @@ def test_vectorfield_init_different_time_intervals():
 
 def test_field_invalid_interpolator():
     ds = datasets_structured["ds_2d_left"]
-    model = StructuredModelData.from_sgrid_conventions(ds, mesh="flat")
+    model = StructuredModelData.from_sgrid_conventions(ds, mesh="flat", vector_fields=NOTSET)
     field = Field(name="data_g", model=model)
 
     def not_a_scalar_interpolator(particle_positions, grid_positions, field):
@@ -90,7 +91,7 @@ def test_field_invalid_interpolator():
 
 def test_vectorfield_invalid_interpolator():
     ds = datasets_structured["ds_2d_left"]
-    model = StructuredModelData.from_sgrid_conventions(ds, mesh="flat")
+    model = StructuredModelData.from_sgrid_conventions(ds, mesh="flat", vector_fields=NOTSET)
     fields = {f.name: f for f in model.construct_fields()}
     U = fields["U_A_grid"]
     V = fields["V_A_grid"]

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -208,6 +208,18 @@ def test_fieldset_from_sgrid_conventions(ds_name):
     assert len(fieldset.fields) > 0
 
 
+def test_fieldset_add_error_on_duplicate_fields():
+    """Test that adding FieldSets with overlapping field names raises a ValueError."""
+    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+    ds2 = ds1.copy()
+
+    fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat")
+    fset2 = FieldSet.from_sgrid_conventions(ds2, mesh="flat")
+
+    with pytest.raises(ValueError, match="field names in common.*'U'"):
+        fset1 + fset2
+
+
 def test_fieldset_add():
     """Test that two FieldSets can be combined with + (fset1 + fset2)."""
     ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "grid"]].rename({"U_A_grid": "U1"})
@@ -223,19 +235,7 @@ def test_fieldset_add():
     assert "V2" in fset.fields
 
 
-def test_fieldset_add_overlapping_fields():
-    """Test that adding FieldSets with overlapping field names raises a ValueError."""
-    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "grid"]].rename({"U_A_grid": "U"})
-    ds2 = datasets_structured["ds_2d_left"][["V_A_grid", "grid"]].rename({"V_A_grid": "U"})
-
-    fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat")
-    fset2 = FieldSet.from_sgrid_conventions(ds2, mesh="flat")
-
-    with pytest.raises(ValueError, match="field names in common.*'U'"):
-        fset1 + fset2
-
-
-def test_fieldset_add_overlapping_context_values():
+def test_fieldset_add_error_on_duplicate_context_values():
     """Test that adding FieldSets with overlapping context value names raises a ValueError."""
     ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "grid"]].rename({"U_A_grid": "U1"})
     ds2 = datasets_structured["ds_2d_left"][["V_A_grid", "grid"]].rename({"V_A_grid": "V2"})

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -8,6 +8,7 @@ import pytest
 
 from parcels import Field, ParticleFile, ParticleSet, XGrid, convert
 from parcels._core.fieldset import FieldSet, _datetime_to_msg
+from parcels._core.model import _default_vector_field_components
 from parcels._datasets.structured.generic import datasets as datasets_structured
 from parcels._datasets.structured.generic import datasets_sgrid
 from parcels._datasets.unstructured.generic import datasets as datasets_unstructured
@@ -126,7 +127,17 @@ def test_fieldset_vectorfield_none():
     assert "UV" not in fset1.fields
 
 
-def test_resolve_vector_field_components(): ...
+@pytest.mark.parametrize(
+    "data_vars,expected",
+    [
+        (["U", "V", "land_mask"], {"UV": ("U", "V")}),
+        (["U", "V", "W", "land_mask"], {"UV": ("U", "V"), "UVW": ("U", "V", "W")}),
+        (["field1", "field2", "field3"], {}),
+    ],
+)
+def test_default_vector_field_components(data_vars, expected):
+    got = _default_vector_field_components(data_vars)
+    assert got == expected
 
 
 # TODO restructure: use adding of fieldset notation to test this

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -231,8 +231,10 @@ def test_fieldset_add():
     fset = fset1 + fset2
 
     assert len(fset.models) == len(fset1.models) + len(fset2.models)
-    assert "U1" in fset.fields
-    assert "V2" in fset.fields
+
+    fields_before = list(fset1.fields.keys()) + list(fset2.fields.keys())
+    assert len(fields_before) == len(fset.fields)
+    assert set(fields_before) == set(fset.fields.keys())
 
 
 def test_fieldset_add_error_on_duplicate_context_values():

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -326,11 +326,13 @@ def test_fieldset_add_error_on_duplicate_fields():
 
 def test_fieldset_add():
     """Test that two FieldSets can be combined with + (fset1 + fset2)."""
-    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "grid"]].rename({"U_A_grid": "U1"})
-    ds2 = datasets_structured["ds_2d_left"][["V_A_grid", "grid"]].rename({"V_A_grid": "V2"})
+    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+    ds2 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename(
+        {"U_A_grid": "U_wind", "V_A_grid": "V_wind"}
+    )
 
     fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat")
-    fset2 = FieldSet.from_sgrid_conventions(ds2, mesh="flat")
+    fset2 = FieldSet.from_sgrid_conventions(ds2, mesh="flat", vector_fields={"UV_wind": ("U_wind", "V_wind")})
 
     fset = fset1 + fset2
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from datetime import timedelta
 
 import cf_xarray  # noqa: F401
@@ -95,6 +96,34 @@ def test_fieldset_from_structured_generic_datasets(ds):
         utils.assert_valid_field_data(field.data, field.grid)
 
     assert len(fieldset.gridset) == 1
+
+
+@pytest.mark.parametrize(
+    "vector_fields,ctx",
+    [
+        pytest.param(
+            {"UV": ("U",)},
+            pytest.raises(ValueError, match="must have either 2 or 3 components"),
+            id="single-component",
+        ),
+        pytest.param(
+            {"UV": ("U", "missing")},
+            pytest.raises(ValueError, match="not present in the source dataset"),
+            id="component-not-in-dataset",
+        ),
+        pytest.param(
+            {"UV": ("U", "U", "U", "U")},
+            pytest.raises(ValueError, match="must have either 2 or 3 components"),
+            id="too-many-components",
+        ),
+        pytest.param(None, nullcontext(), id="None"),
+    ],
+)
+def test_fieldset_invalid_vector_fields(vector_fields, ctx):
+    ds = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+
+    with ctx:
+        FieldSet.from_sgrid_conventions(ds, mesh="flat", vector_fields=vector_fields)
 
 
 def test_fieldset_structured_vectorfield_default():

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -96,9 +96,6 @@ def test_fieldset_from_structured_generic_datasets(ds):
     assert len(fieldset.gridset) == 1
 
 
-def test_fieldset_gridset_multiple_grids(): ...
-
-
 # TODO restructure: use adding of fieldset notation to test this
 @pytest.mark.skip("Needs updating after refactoring from https://github.com/Parcels-code/Parcels/pull/2646")
 def test_fieldset_time_interval():

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -97,35 +97,35 @@ def test_fieldset_from_structured_generic_datasets(ds):
     assert len(fieldset.gridset) == 1
 
 
-def test_fieldset_vectorfield_default():
-    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+def test_fieldset_structured_vectorfield_default():
+    ds = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
 
-    fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat")
+    fset = FieldSet.from_sgrid_conventions(ds, mesh="flat")
 
-    assert "U" in fset1.fields
-    assert "V" in fset1.fields
-    assert "UV" in fset1.fields
-
-
-def test_fieldset_vectorfield_custom():
-    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
-    ds1 = ds1.rename({"U": "U_wind", "V": "V_wind"})
-
-    fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat", vector_fields={"UV_wind": ("U_wind", "V_wind")})
-
-    assert "U_wind" in fset1.fields
-    assert "V_wind" in fset1.fields
-    assert "UV_wind" in fset1.fields
+    assert "U" in fset.fields
+    assert "V" in fset.fields
+    assert "UV" in fset.fields
 
 
-def test_fieldset_vectorfield_none():
-    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+def test_fieldset_structured_vectorfield_custom():
+    ds = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+    ds = ds.rename({"U": "U_wind", "V": "V_wind"})
 
-    fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat", vector_fields=None)
+    fset = FieldSet.from_sgrid_conventions(ds, mesh="flat", vector_fields={"UV_wind": ("U_wind", "V_wind")})
 
-    assert "U" in fset1.fields
-    assert "V" in fset1.fields
-    assert "UV" not in fset1.fields
+    assert "U_wind" in fset.fields
+    assert "V_wind" in fset.fields
+    assert "UV_wind" in fset.fields
+
+
+def test_fieldset_structured_vectorfield_none():
+    ds = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+
+    fset = FieldSet.from_sgrid_conventions(ds, mesh="flat", vector_fields=None)
+
+    assert "U" in fset.fields
+    assert "V" in fset.fields
+    assert "UV" not in fset.fields
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -128,6 +128,36 @@ def test_fieldset_structured_vectorfield_none():
     assert "UV" not in fset.fields
 
 
+def test_fieldset_unstructured_vectorfield_default():
+    ds = datasets_unstructured["stommel_gyre_delaunay"]
+    fset = FieldSet.from_ugrid_conventions(ds, mesh="spherical")
+
+    assert "U" in fset.fields
+    assert "V" in fset.fields
+    assert "UV" in fset.fields
+
+
+def test_fieldset_unstructured_vectorfield_custom():
+    ds = datasets_unstructured["stommel_gyre_delaunay"]
+    ds = ds.rename({"U": "U_wind", "V": "V_wind"})
+
+    fset = FieldSet.from_ugrid_conventions(ds, mesh="spherical", vector_fields={"UV_wind": ("U_wind", "V_wind")})
+
+    assert "U_wind" in fset.fields
+    assert "V_wind" in fset.fields
+    assert "UV_wind" in fset.fields
+
+
+def test_fieldset_unstructured_vectorfield_none():
+    ds = datasets_unstructured["stommel_gyre_delaunay"]
+
+    fset = FieldSet.from_ugrid_conventions(ds, mesh="spherical", vector_fields=None)
+
+    assert "U" in fset.fields
+    assert "V" in fset.fields
+    assert "UV" not in fset.fields
+
+
 @pytest.mark.parametrize(
     "data_vars,expected",
     [

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -96,6 +96,39 @@ def test_fieldset_from_structured_generic_datasets(ds):
     assert len(fieldset.gridset) == 1
 
 
+def test_fieldset_vectorfield_default():
+    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+
+    fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat")
+
+    assert "U" in fset1.fields
+    assert "V" in fset1.fields
+    assert "UV" in fset1.fields
+
+
+def test_fieldset_vectorfield_custom():
+    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+
+    fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat", vector_fields={"UV_wind": ("U_wind", "V_wind")})
+
+    assert "U_wind" in fset1.fields
+    assert "V_wind" in fset1.fields
+    assert "UV_wind" in fset1.fields
+
+
+def test_fieldset_vectorfield_none():
+    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+
+    fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat", vector_fields=None)
+
+    assert "U" in fset1.fields
+    assert "V" in fset1.fields
+    assert "UV" not in fset1.fields
+
+
+def test_resolve_vector_field_components(): ...
+
+
 # TODO restructure: use adding of fieldset notation to test this
 @pytest.mark.skip("Needs updating after refactoring from https://github.com/Parcels-code/Parcels/pull/2646")
 def test_fieldset_time_interval():

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -1,4 +1,3 @@
-from contextlib import nullcontext
 from datetime import timedelta
 
 import cf_xarray  # noqa: F401
@@ -116,7 +115,11 @@ def test_fieldset_from_structured_generic_datasets(ds):
             pytest.raises(ValueError, match="must have either 2 or 3 components"),
             id="too-many-components",
         ),
-        pytest.param(None, nullcontext(), id="None"),
+        pytest.param(
+            None,
+            pytest.raises(ValueError, match="vector_fields must be a dictionary"),
+            id="None",
+        ),
     ],
 )
 def test_fieldset_invalid_vector_fields(vector_fields, ctx):
@@ -147,10 +150,10 @@ def test_fieldset_structured_vectorfield_custom():
     assert "UV_wind" in fset.fields
 
 
-def test_fieldset_structured_vectorfield_none():
+def test_fieldset_structured_vectorfield_empty():
     ds = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
 
-    fset = FieldSet.from_sgrid_conventions(ds, mesh="flat", vector_fields=None)
+    fset = FieldSet.from_sgrid_conventions(ds, mesh="flat", vector_fields={})
 
     assert "U" in fset.fields
     assert "V" in fset.fields
@@ -177,10 +180,10 @@ def test_fieldset_unstructured_vectorfield_custom():
     assert "UV_wind" in fset.fields
 
 
-def test_fieldset_unstructured_vectorfield_none():
+def test_fieldset_unstructured_vectorfield_empty():
     ds = datasets_unstructured["stommel_gyre_delaunay"]
 
-    fset = FieldSet.from_ugrid_conventions(ds, mesh="spherical", vector_fields=None)
+    fset = FieldSet.from_ugrid_conventions(ds, mesh="spherical", vector_fields={})
 
     assert "U" in fset.fields
     assert "V" in fset.fields

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -109,6 +109,7 @@ def test_fieldset_vectorfield_default():
 
 def test_fieldset_vectorfield_custom():
     ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+    ds1 = ds1.rename({"U": "U_wind", "V": "V_wind"})
 
     fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat", vector_fields={"UV_wind": ("U_wind", "V_wind")})
 


### PR DESCRIPTION
### Description

This PR adds a `vector_fields` parameter which allows users to control vector fields that are created.

Looking at the following tests you can see how they're used

```python

def test_fieldset_structured_vectorfield_default():
    ds = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})

    fset = FieldSet.from_sgrid_conventions(ds, mesh="flat")

    assert "U" in fset.fields
    assert "V" in fset.fields
    assert "UV" in fset.fields


def test_fieldset_structured_vectorfield_custom():
    ds = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
    ds = ds.rename({"U": "U_wind", "V": "V_wind"})

    fset = FieldSet.from_sgrid_conventions(ds, mesh="flat", vector_fields={"UV_wind": ("U_wind", "V_wind")})

    assert "U_wind" in fset.fields
    assert "V_wind" in fset.fields
    assert "UV_wind" in fset.fields


def test_fieldset_structured_vectorfield_none():
    ds = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})

    fset = FieldSet.from_sgrid_conventions(ds, mesh="flat", vector_fields=None)

    assert "U" in fset.fields
    assert "V" in fset.fields
    assert "UV" not in fset.fields
```

Now users can:
- specify the names of vectorfields and their components
- explicitly set that no vector fields are created (by doing `vector_fields = {}` or `vector_fields = None`)

If `vector_fields` is not provided it uses the default behaviour of constructing UV and UVW if the component fields are present.

These changes have also been added to the unstructured grid side as well.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2695 
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt): only for updating the docstring
