### PR TITLE
Pin xgcm version

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -30,7 +30,7 @@ holoviews = ">=1.22.0" # https://github.com/prefix-dev/rattler-build/issues/2326
 uxarray = ">=2026.04.1"
 dask = ">=2024.5.1"
 zarr = ">=3"
-xgcm = { git = "https://github.com/xgcm/xgcm", rev = "master" } # TODO: Switch to release version after release is cut
+xgcm = { git = "https://github.com/xgcm/xgcm", rev = "532a3c567c475cbe192f49b9961f8117806bbfb7" } # TODO: Switch to release version after release is cut
 cf_xarray = ">=0.8.6"
 cftime = ">=1.6.3"
 pooch = ">=1.8.0"


### PR DESCRIPTION
### Description

https://github.com/xgcm/xgcm/pull/743 resulted in the dropping of Axis from the public API hence we can't use it for typechecking. We'll very likely drop xgcm entirely before release, so just pinning for now.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None