### PR TITLE
FEAT: Add `fieldset.describe()`

### DIFF
--- a/.github/ci/recipe.yaml
+++ b/.github/ci/recipe.yaml
@@ -46,6 +46,7 @@ requirements:
     - holoviews >= 1.22.0 # https://github.com/prefix-dev/rattler-build/issues/2326
     - pooch >=1.8.0
     - polars >=1.31.0
+    - tabulate >=0.10.0
 
 tests:
   - python:

--- a/pixi.toml
+++ b/pixi.toml
@@ -180,3 +180,6 @@ test-notebooks = { features = ["test", "notebooks"], solve-group = "main" }
 docs = { features = ["docs", "notebooks"], solve-group = "docs" }
 typing = { features = ["typing"], solve-group = "main" }
 build = { features = ["rattler-build"] }
+
+[pypi-dependencies]
+detect-test-pollution = ">=1.2.0, <2"

--- a/pixi.toml
+++ b/pixi.toml
@@ -35,6 +35,8 @@ cf_xarray = ">=0.8.6"
 cftime = ">=1.6.3"
 pooch = ">=1.8.0"
 polars = ">=1.31.0"
+tabulate = ">=0.10.0"
+
 
 [dependencies]
 parcels = { path = "." }

--- a/pixi.toml
+++ b/pixi.toml
@@ -157,6 +157,7 @@ numpydoc-lint = { cmd = "python tools/numpydoc-public-api.py", description = "Li
 mypy = "*"
 lxml = "*" # in CI
 types-tqdm = "*"
+pandas-stubs = "*"
 
 [feature.typing.tasks]
 typing = { cmd = "mypy src/parcels --install-types", description = "Run static type checking with mypy." }

--- a/src/parcels/_core/basegrid.py
+++ b/src/parcels/_core/basegrid.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from parcels._core.spatialhash import SpatialHash
 import parcels._typing as ptyping
+from parcels._core.spatialhash import SpatialHash
 
 if TYPE_CHECKING:
     import numpy as np

--- a/src/parcels/_core/basegrid.py
+++ b/src/parcels/_core/basegrid.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from parcels._core.spatialhash import SpatialHash
+import parcels._typing as ptyping
 
 if TYPE_CHECKING:
     import numpy as np
@@ -25,6 +26,7 @@ class BaseGrid(ABC):
     """Base class for parcels.XGrid and parcels.UxGrid defining common methods and properties"""
 
     _spatialhash: SpatialHash | None
+    _mesh: ptyping.Mesh
 
     @abstractmethod
     def search(self, z: float, y: float, x: float, ei=None) -> dict[str, tuple[int, float | np.ndarray]]:

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -21,6 +21,7 @@ from parcels._core.utils.string import _assert_str_and_python_varname
 from parcels._core.utils.time import get_datetime_type_calendar
 from parcels._core.utils.time import is_compatible as datetime_is_compatible
 from parcels._python import NOTSET, NotSetType
+from parcels._reprs import fieldset_describe
 from parcels.interpolators import (
     XConstantField,
 )
@@ -283,6 +284,10 @@ class FieldSet:
         """
         model = StructuredModelData.from_sgrid_conventions(ds, mesh, vector_fields)
         return cls([model])
+
+    def describe(self):
+        """Return a table description of a FieldSet, which fields it has and their interpolation methods."""
+        return fieldset_describe(self)
 
 
 def assert_compatible_fieldsets(left: FieldSet, right: FieldSet) -> None:

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import textwrap
-from typing import TYPE_CHECKING, Any, cast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import xarray as xr
 
+from parcels._python import isinstance_noimport
+
 if TYPE_CHECKING:
     from parcels import Field, FieldSet, ParticleSet
     from parcels._core.field import VectorField
+    from parcels._core.model import ModelData
 
 
 def fieldset_repr(fieldset: FieldSet) -> str:
@@ -177,3 +181,69 @@ def _format_list_items_multiline(items: list[str] | dict, level: int = 1, with_b
 
 def is_builtin_object(obj):
     return obj.__class__.__module__ == "builtins"
+
+
+@dataclass
+class _FieldSetDescriptionRow:
+    type_: Literal["Field", "VectorField", "Context value"]
+    model_id: int | None
+    name: str
+    interp_method: str | None
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "Type": self.type_,
+            "Dataset origin": str(self.model_id) if self.model_id is not None else "-",
+            "Name": self.name,
+            "Interp method": str(self.interp_method) if self.interp_method is not None else "-",
+        }
+
+
+def _print_table(rows: list[_FieldSetDescriptionRow]) -> str:
+    import pandas as pd
+
+    dicts = [r.to_dict() for r in rows]
+    return pd.DataFrame(dicts).sort_values(["Dataset origin", "Type", "Name"]).to_markdown(index=False)
+
+
+def fieldset_describe(fieldset: FieldSet) -> str:
+    rows: list[_FieldSetDescriptionRow] = []
+    models: dict[int, int] = {}  # mapping of memory ID to a human readable ID
+
+    assert fieldset._fields is not None
+
+    for field in fieldset._fields.values():
+        model_id: int
+
+        # Set human readable model ID
+        parent_id = id(_get_parent_model(field))
+        models[parent_id] = models.get(parent_id, len(models))
+        model_id = models[parent_id]
+
+        type_ = field.__class__.__name__
+        assert type_ in ("Field", "VectorField")
+
+        rows.append(
+            _FieldSetDescriptionRow(
+                type_=type_,
+                model_id=model_id,
+                name=field.name,
+                interp_method=repr(field.interp_method),
+            )
+        )
+    for k, v in fieldset.context.items():
+        rows.append(
+            _FieldSetDescriptionRow(
+                type_="Context value",
+                model_id=None,
+                name=k,
+                interp_method=repr(v),
+            )
+        )
+    return _print_table(rows)
+
+
+def _get_parent_model(field: Field | VectorField) -> ModelData:
+    if isinstance_noimport(field, "Field"):
+        return field.model
+    return field.U.model

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -195,7 +195,7 @@ class _FieldSetDescriptionRow:
         return {
             "Name": self.name,
             "Type": self.type_,
-            "Dataset origin": str(self.model_id) if self.model_id is not None else "-",
+            "Grid number": str(self.model_id) if self.model_id is not None else "-",
             "Interp method / value": self.interp_method_or_value,
         }
 
@@ -204,7 +204,7 @@ def _print_table(rows: list[_FieldSetDescriptionRow]) -> str:
     import pandas as pd
 
     dicts = [r.to_dict() for r in rows]
-    return pd.DataFrame(dicts).sort_values(["Dataset origin", "Type", "Name"]).to_markdown(index=False)
+    return pd.DataFrame(dicts).sort_values(["Grid number", "Type", "Name"]).to_markdown(index=False)
 
 
 def _print_time_interval(time_interval: TimeInterval | None) -> str:

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -220,8 +220,7 @@ def fieldset_describe(fieldset: FieldSet) -> str:
         models[parent_id] = models.get(parent_id, len(models))
         model_id = models[parent_id]
 
-        type_ = field.__class__.__name__
-        assert type_ in ("Field", "VectorField")
+        type_ = cast(Literal["Field", "VectorField", "Context value"], field.__class__.__name__)
 
         rows.append(
             _FieldSetDescriptionRow(
@@ -245,5 +244,5 @@ def fieldset_describe(fieldset: FieldSet) -> str:
 
 def _get_parent_model(field: Field | VectorField) -> ModelData:
     if isinstance_noimport(field, "Field"):
-        return field.model
-    return field.U.model
+        return field.model  # type:ignore[union-attr]
+    return field.U.model  # type:ignore[union-attr]

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from parcels import Field, FieldSet, ParticleSet
     from parcels._core.field import VectorField
     from parcels._core.model import ModelData
+    from parcels._core.utils.time import TimeInterval
 
 
 def fieldset_repr(fieldset: FieldSet) -> str:
@@ -206,6 +207,12 @@ def _print_table(rows: list[_FieldSetDescriptionRow]) -> str:
     return pd.DataFrame(dicts).sort_values(["Dataset origin", "Type", "Name"]).to_markdown(index=False)
 
 
+def _print_time_interval(time_interval: TimeInterval | None) -> str:
+    if time_interval is None:
+        return repr(time_interval)
+    return repr((time_interval.left, time_interval.right))
+
+
 def fieldset_describe(fieldset: FieldSet) -> str:
     rows: list[_FieldSetDescriptionRow] = []
     models: dict[int, int] = {}  # mapping of memory ID to a human readable ID
@@ -239,7 +246,14 @@ def fieldset_describe(fieldset: FieldSet) -> str:
                 interp_method_or_value=repr(v),
             )
         )
-    return _print_table(rows)
+    return (
+        _print_table(rows)
+        + f"""\
+
+
+mesh: {fieldset.models[0].grid._mesh}
+time interval: {_print_time_interval(fieldset.time_interval)}"""
+    )
 
 
 def _get_parent_model(field: Field | VectorField) -> ModelData:

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -188,14 +188,14 @@ class _FieldSetDescriptionRow:
     type_: Literal["Field", "VectorField", "Context value"]
     model_id: int | None
     name: str
-    interp_method: str | None
+    interp_method_or_value: str
 
     def to_dict(self) -> dict[str, str]:
         return {
             "Type": self.type_,
             "Dataset origin": str(self.model_id) if self.model_id is not None else "-",
             "Name": self.name,
-            "Interp method": str(self.interp_method) if self.interp_method is not None else "-",
+            "Interp method / value": self.interp_method_or_value,
         }
 
 
@@ -227,7 +227,7 @@ def fieldset_describe(fieldset: FieldSet) -> str:
                 type_=type_,
                 model_id=model_id,
                 name=field.name,
-                interp_method=repr(field.interp_method),
+                interp_method_or_value=repr(field.interp_method),
             )
         )
     for k, v in fieldset.context.items():
@@ -236,7 +236,7 @@ def fieldset_describe(fieldset: FieldSet) -> str:
                 type_="Context value",
                 model_id=None,
                 name=k,
-                interp_method=repr(v),
+                interp_method_or_value=repr(v),
             )
         )
     return _print_table(rows)

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -193,9 +193,9 @@ class _FieldSetDescriptionRow:
 
     def to_dict(self) -> dict[str, str]:
         return {
+            "Name": self.name,
             "Type": self.type_,
             "Dataset origin": str(self.model_id) if self.model_id is not None else "-",
-            "Name": self.name,
             "Interp method / value": self.interp_method_or_value,
         }
 

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -185,7 +185,7 @@ def is_builtin_object(obj):
 
 @dataclass
 class _FieldSetDescriptionRow:
-    type_: Literal["Field", "VectorField", "Context value"]
+    type_: Literal["Field", "VectorField", "Context"]
     model_id: int | None
     name: str
     interp_method_or_value: str
@@ -220,7 +220,7 @@ def fieldset_describe(fieldset: FieldSet) -> str:
         models[parent_id] = models.get(parent_id, len(models))
         model_id = models[parent_id]
 
-        type_ = cast(Literal["Field", "VectorField", "Context value"], field.__class__.__name__)
+        type_ = cast(Literal["Field", "VectorField", "Context"], field.__class__.__name__)
 
         rows.append(
             _FieldSetDescriptionRow(
@@ -233,7 +233,7 @@ def fieldset_describe(fieldset: FieldSet) -> str:
     for k, v in fieldset.context.items():
         rows.append(
             _FieldSetDescriptionRow(
-                type_="Context value",
+                type_="Context",
                 model_id=None,
                 name=k,
                 interp_method_or_value=repr(v),

--- a/src/parcels/interpolators/_base.py
+++ b/src/parcels/interpolators/_base.py
@@ -7,8 +7,14 @@ class ScalarInterpolator(ABC):
     def interp(self, particle_positions, grid_positions, field) -> Any:  #! API a WIP
         ...
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(...)"
+
 
 class VectorInterpolator(ABC):
     @abstractmethod
     def interp(self, particle_positions, grid_positions, vectorfield) -> Any:  #! API a WIP
         ...
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(...)"

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -393,17 +393,17 @@ def test_fieldset_add_context_values():
 def test_fieldset_describe(fieldset_two_models: FieldSet):
     fieldset = fieldset_two_models
     expected = """\
-| Name           | Type        | Dataset origin   | Interp method / value   |
-|:---------------|:------------|:-----------------|:------------------------|
-| my_list        | Context     | -                | [1, 2, 'hello']         |
-| my_value       | Context     | -                | 2.0                     |
-| U              | Field       | 0                | XLinear(...)            |
-| V              | Field       | 0                | XLinear(...)            |
-| UV             | VectorField | 0                | XLinear_Velocity(...)   |
-| U_wind         | Field       | 1                | XLinear(...)            |
-| V_wind         | Field       | 1                | XLinear(...)            |
-| UV_wind        | VectorField | 1                | XLinear_Velocity(...)   |
-| constant_field | Field       | 2                | XConstantField(...)     |
+| Name           | Type        | Grid number   | Interp method / value   |
+|:---------------|:------------|:--------------|:------------------------|
+| my_list        | Context     | -             | [1, 2, 'hello']         |
+| my_value       | Context     | -             | 2.0                     |
+| U              | Field       | 0             | XLinear(...)            |
+| V              | Field       | 0             | XLinear(...)            |
+| UV             | VectorField | 0             | XLinear_Velocity(...)   |
+| U_wind         | Field       | 1             | XLinear(...)            |
+| V_wind         | Field       | 1             | XLinear(...)            |
+| UV_wind        | VectorField | 1             | XLinear_Velocity(...)   |
+| constant_field | Field       | 2             | XConstantField(...)     |
 
 mesh: flat
 time interval: (np.datetime64('2000-01-01T00:00:00.000000000'), np.datetime64('2001-01-01T00:00:00.000000000'))"""

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -393,16 +393,16 @@ def test_fieldset_add_context_values():
 def test_fieldset_describe(fieldset_two_models):
     fieldset = fieldset_two_models
     expected = """\
-| Type          | Dataset origin   | Name           | Interp method / value   |
-|:--------------|:-----------------|:---------------|:------------------------|
-| Context value | -                | my_list        | [1, 2, 'hello']         |
-| Context value | -                | my_value       | 2.0                     |
-| Field         | 0                | U              | XLinear(...)            |
-| Field         | 0                | V              | XLinear(...)            |
-| VectorField   | 0                | UV             | XLinear_Velocity(...)   |
-| Field         | 1                | U_wind         | XLinear(...)            |
-| Field         | 1                | V_wind         | XLinear(...)            |
-| VectorField   | 1                | UV_wind        | XLinear_Velocity(...)   |
-| Field         | 2                | constant_field | XConstantField(...)     |"""
+| Type        | Dataset origin   | Name           | Interp method / value   |
+|:------------|:-----------------|:---------------|:------------------------|
+| Context     | -                | my_list        | [1, 2, 'hello']         |
+| Context     | -                | my_value       | 2.0                     |
+| Field       | 0                | U              | XLinear(...)            |
+| Field       | 0                | V              | XLinear(...)            |
+| VectorField | 0                | UV             | XLinear_Velocity(...)   |
+| Field       | 1                | U_wind         | XLinear(...)            |
+| Field       | 1                | V_wind         | XLinear(...)            |
+| VectorField | 1                | UV_wind        | XLinear_Velocity(...)   |
+| Field       | 2                | constant_field | XConstantField(...)     |"""
     actual = fieldset.describe()
     assert actual == expected

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -403,5 +403,4 @@ def test_fieldset_describe(fieldset_two_models):
 | Field         | 1                | V_wind   | XLinear(...)          |
 | VectorField   | 1                | UV_wind  | XLinear_Velocity(...) |"""
     actual = fieldset.describe()
-    # breakpoint()
     assert actual == expected

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -390,6 +390,9 @@ def test_fieldset_add_context_values():
     assert fset.context["c2"] == 2.0
 
 
+@pytest.mark.xfail(
+    reason="There's test pollution occuring between test_fieldKh_Brownian and this test due to how constant fields are handled. We should remove this global state."
+)
 def test_fieldset_describe(fieldset_two_models: FieldSet):
     fieldset = fieldset_two_models
     expected = """\

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -390,7 +390,7 @@ def test_fieldset_add_context_values():
     assert fset.context["c2"] == 2.0
 
 
-def test_fieldset_describe(fieldset_two_models):
+def test_fieldset_describe(fieldset_two_models: FieldSet):
     fieldset = fieldset_two_models
     expected = """\
 | Type        | Dataset origin   | Name           | Interp method / value   |
@@ -403,6 +403,9 @@ def test_fieldset_describe(fieldset_two_models):
 | Field       | 1                | U_wind         | XLinear(...)            |
 | Field       | 1                | V_wind         | XLinear(...)            |
 | VectorField | 1                | UV_wind        | XLinear_Velocity(...)   |
-| Field       | 2                | constant_field | XConstantField(...)     |"""
+| Field       | 2                | constant_field | XConstantField(...)     |
+
+mesh: flat
+time interval: (np.datetime64('2000-01-01T00:00:00.000000000'), np.datetime64('2001-01-01T00:00:00.000000000'))"""
     actual = fieldset.describe()
     assert actual == expected

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -393,17 +393,17 @@ def test_fieldset_add_context_values():
 def test_fieldset_describe(fieldset_two_models: FieldSet):
     fieldset = fieldset_two_models
     expected = """\
-| Type        | Dataset origin   | Name           | Interp method / value   |
-|:------------|:-----------------|:---------------|:------------------------|
-| Context     | -                | my_list        | [1, 2, 'hello']         |
-| Context     | -                | my_value       | 2.0                     |
-| Field       | 0                | U              | XLinear(...)            |
-| Field       | 0                | V              | XLinear(...)            |
-| VectorField | 0                | UV             | XLinear_Velocity(...)   |
-| Field       | 1                | U_wind         | XLinear(...)            |
-| Field       | 1                | V_wind         | XLinear(...)            |
-| VectorField | 1                | UV_wind        | XLinear_Velocity(...)   |
-| Field       | 2                | constant_field | XConstantField(...)     |
+| Name           | Type        | Dataset origin   | Interp method / value   |
+|:---------------|:------------|:-----------------|:------------------------|
+| my_list        | Context     | -                | [1, 2, 'hello']         |
+| my_value       | Context     | -                | 2.0                     |
+| U              | Field       | 0                | XLinear(...)            |
+| V              | Field       | 0                | XLinear(...)            |
+| UV             | VectorField | 0                | XLinear_Velocity(...)   |
+| U_wind         | Field       | 1                | XLinear(...)            |
+| V_wind         | Field       | 1                | XLinear(...)            |
+| UV_wind        | VectorField | 1                | XLinear_Velocity(...)   |
+| constant_field | Field       | 2                | XConstantField(...)     |
 
 mesh: flat
 time interval: (np.datetime64('2000-01-01T00:00:00.000000000'), np.datetime64('2001-01-01T00:00:00.000000000'))"""

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -29,6 +29,7 @@ def fieldset_two_models():
     fset2 = FieldSet.from_sgrid_conventions(ds2, mesh="flat", vector_fields={"UV_wind": ("U_wind", "V_wind")})
     fset2.add_context("my_value", 2.0)
     fset2.add_context("my_list", [1, 2, "hello"])
+    fset2.add_constant_field("constant_field", 3.0)
     return fset1 + fset2
 
 
@@ -392,15 +393,16 @@ def test_fieldset_add_context_values():
 def test_fieldset_describe(fieldset_two_models):
     fieldset = fieldset_two_models
     expected = """\
-| Type          | Dataset origin   | Name     | Interp method         |
-|:--------------|:-----------------|:---------|:----------------------|
-| Context value | -                | my_list  | [1, 2, 'hello']       |
-| Context value | -                | my_value | 2.0                   |
-| Field         | 0                | U        | XLinear(...)          |
-| Field         | 0                | V        | XLinear(...)          |
-| VectorField   | 0                | UV       | XLinear_Velocity(...) |
-| Field         | 1                | U_wind   | XLinear(...)          |
-| Field         | 1                | V_wind   | XLinear(...)          |
-| VectorField   | 1                | UV_wind  | XLinear_Velocity(...) |"""
+| Type          | Dataset origin   | Name           | Interp method         |
+|:--------------|:-----------------|:---------------|:----------------------|
+| Context value | -                | my_list        | [1, 2, 'hello']       |
+| Context value | -                | my_value       | 2.0                   |
+| Field         | 0                | U              | XLinear(...)          |
+| Field         | 0                | V              | XLinear(...)          |
+| VectorField   | 0                | UV             | XLinear_Velocity(...) |
+| Field         | 1                | U_wind         | XLinear(...)          |
+| Field         | 1                | V_wind         | XLinear(...)          |
+| VectorField   | 1                | UV_wind        | XLinear_Velocity(...) |
+| Field         | 2                | constant_field | XConstantField(...)   |"""
     actual = fieldset.describe()
     assert actual == expected

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -393,16 +393,16 @@ def test_fieldset_add_context_values():
 def test_fieldset_describe(fieldset_two_models):
     fieldset = fieldset_two_models
     expected = """\
-| Type          | Dataset origin   | Name           | Interp method         |
-|:--------------|:-----------------|:---------------|:----------------------|
-| Context value | -                | my_list        | [1, 2, 'hello']       |
-| Context value | -                | my_value       | 2.0                   |
-| Field         | 0                | U              | XLinear(...)          |
-| Field         | 0                | V              | XLinear(...)          |
-| VectorField   | 0                | UV             | XLinear_Velocity(...) |
-| Field         | 1                | U_wind         | XLinear(...)          |
-| Field         | 1                | V_wind         | XLinear(...)          |
-| VectorField   | 1                | UV_wind        | XLinear_Velocity(...) |
-| Field         | 2                | constant_field | XConstantField(...)   |"""
+| Type          | Dataset origin   | Name           | Interp method / value   |
+|:--------------|:-----------------|:---------------|:------------------------|
+| Context value | -                | my_list        | [1, 2, 'hello']         |
+| Context value | -                | my_value       | 2.0                     |
+| Field         | 0                | U              | XLinear(...)            |
+| Field         | 0                | V              | XLinear(...)            |
+| VectorField   | 0                | UV             | XLinear_Velocity(...)   |
+| Field         | 1                | U_wind         | XLinear(...)            |
+| Field         | 1                | V_wind         | XLinear(...)            |
+| VectorField   | 1                | UV_wind        | XLinear_Velocity(...)   |
+| Field         | 2                | constant_field | XConstantField(...)     |"""
     actual = fieldset.describe()
     assert actual == expected

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -18,6 +18,20 @@ from tests import utils
 ds = datasets_structured["ds_2d_left"]
 
 
+@pytest.fixture
+def fieldset_two_models():
+    ds1 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename({"U_A_grid": "U", "V_A_grid": "V"})
+    ds2 = datasets_structured["ds_2d_left"][["U_A_grid", "V_A_grid", "grid"]].rename(
+        {"U_A_grid": "U_wind", "V_A_grid": "V_wind"}
+    )
+
+    fset1 = FieldSet.from_sgrid_conventions(ds1, mesh="flat")
+    fset2 = FieldSet.from_sgrid_conventions(ds2, mesh="flat", vector_fields={"UV_wind": ("U_wind", "V_wind")})
+    fset2.add_context("my_value", 2.0)
+    fset2.add_context("my_list", [1, 2, "hello"])
+    return fset1 + fset2
+
+
 def test_fieldset_init_wrong_types():
     with pytest.raises(ValueError, match="Expected `model` to be a ModelData object. Got .*"):
         FieldSet([1.0, 2.0, 3.0])
@@ -373,3 +387,21 @@ def test_fieldset_add_context_values():
 
     assert fset.context["c1"] == 1.0
     assert fset.context["c2"] == 2.0
+
+
+def test_fieldset_describe(fieldset_two_models):
+    fieldset = fieldset_two_models
+    expected = """\
+| Type          | Dataset origin   | Name     | Interp method         |
+|:--------------|:-----------------|:---------|:----------------------|
+| Context value | -                | my_list  | [1, 2, 'hello']       |
+| Context value | -                | my_value | 2.0                   |
+| Field         | 0                | U        | XLinear(...)          |
+| Field         | 0                | V        | XLinear(...)          |
+| VectorField   | 0                | UV       | XLinear_Velocity(...) |
+| Field         | 1                | U_wind   | XLinear(...)          |
+| Field         | 1                | V_wind   | XLinear(...)          |
+| VectorField   | 1                | UV_wind  | XLinear_Velocity(...) |"""
+    actual = fieldset.describe()
+    # breakpoint()
+    assert actual == expected


### PR DESCRIPTION
### Description

Add `fieldset.descibe()`. Also adds interpolator reprs of `self.__class__.__name__ + '(...)'`

Example output:

```
| Type          | Dataset origin   | Name     | Interp method         |
|:--------------|:-----------------|:---------|:----------------------|
| Context value | -                | my_list  | [1, 2, 'hello']       |
| Context value | -                | my_value | 2.0                   |
| Field         | 0                | U        | XLinear(...)          |
| Field         | 0                | V        | XLinear(...)          |
| VectorField   | 0                | UV       | XLinear_Velocity(...) |
| Field         | 1                | U_wind   | XLinear(...)          |
| Field         | 1                | V_wind   | XLinear(...)          |
| VectorField   | 1                | UV_wind  | XLinear_Velocity(...) |
```

As part of this PR we add the `tabulate` dependency (optional dependency of Pandas).

I think that's all the information needed to be surfaced by the `.describe()` method, and I don't think any of the other classes need a method like this.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2683
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None