### PR TITLE
Load no-time vars as numpy arrays in to_windowed_arrays

### DIFF
--- a/src/parcels/_core/_windowed_array.py
+++ b/src/parcels/_core/_windowed_array.py
@@ -108,4 +108,6 @@ def maybe_windowed(data: xr.DataArray, max_levels: int | None = None):
         return data
     if data.dims and data.dims[0] == "time" and is_dask_collection(data.data):
         return WindowedArray(data, max_levels=max_levels)
+    elif data.dims and data.dims[0] == "mockT" and is_dask_collection(data.data):
+        return data.compute()
     return data

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -103,10 +103,12 @@ class ModelData(ABC):
             and ``max_levels`` then bounds its size.
         """
         windowed = self.__dict__.setdefault("_windowed", {})
-        for dim in ["lon", "lat", "depth"]:
+        for dim in ["lon", "lat"]:
             # ensure lon and lat are loaded into memory for dask-backed datasets
             if is_dask_collection(self.data[dim]):
                 self.data[dim].load()
+        if "depth" in self.data.dims and is_dask_collection(self.data["depth"]):
+            self.data["depth"].load()
         for name in self.scalar_field_names:
             current = windowed.get(name, self.data[name])
             windowed[name] = maybe_windowed(current, max_levels=max_levels)

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -7,6 +7,7 @@ from typing import Any, Self
 import cf_xarray  # noqa: F401
 import uxarray as ux
 import xarray as xr
+from dask import is_dask_collection
 
 import parcels._sgrid as sgrid
 import parcels._typing as ptyping
@@ -102,6 +103,10 @@ class ModelData(ABC):
             and ``max_levels`` then bounds its size.
         """
         windowed = self.__dict__.setdefault("_windowed", {})
+        for dim in ["lon", "lat", "depth"]:
+            # ensure lon and lat are loaded into memory for dask-backed datasets
+            if is_dask_collection(self.data[dim]):
+                self.data[dim].load()
         for name in self.scalar_field_names:
             current = windowed.get(name, self.data[name])
             windowed[name] = maybe_windowed(current, max_levels=max_levels)

--- a/src/parcels/_core/xgrid.py
+++ b/src/parcels/_core/xgrid.py
@@ -7,6 +7,7 @@ import numpy as np
 import numpy.typing as npt
 import xarray as xr
 import xgcm
+from dask import is_dask_collection
 
 import parcels._sgrid as sgrid
 import parcels._typing as ptyping
@@ -207,6 +208,9 @@ class XGrid(BaseGrid):
             _ = self.xgcm_grid.axes["X"]
         except KeyError:
             return np.zeros(1)
+        # ensure lon is loaded into memory for dask-backed datasets, as it is used in the search method
+        if is_dask_collection(self._ds["lon"].data):
+            self._ds["lon"].load()
         return self._ds["lon"].values
 
     @property
@@ -221,6 +225,9 @@ class XGrid(BaseGrid):
             _ = self.xgcm_grid.axes["Y"]
         except KeyError:
             return np.zeros(1)
+        # ensure lat is loaded into memory for dask-backed datasets, as it is used in the search method
+        if is_dask_collection(self._ds["lat"].data):
+            self._ds["lat"].load()
         return self._ds["lat"].values
 
     @property

--- a/src/parcels/_core/xgrid.py
+++ b/src/parcels/_core/xgrid.py
@@ -7,7 +7,6 @@ import numpy as np
 import numpy.typing as npt
 import xarray as xr
 import xgcm
-from dask import is_dask_collection
 
 import parcels._sgrid as sgrid
 import parcels._typing as ptyping
@@ -208,9 +207,6 @@ class XGrid(BaseGrid):
             _ = self.xgcm_grid.axes["X"]
         except KeyError:
             return np.zeros(1)
-        # ensure lon is loaded into memory for dask-backed datasets, as it is used in the search method
-        if is_dask_collection(self._ds["lon"].data):
-            self._ds["lon"].load()
         return self._ds["lon"].values
 
     @property
@@ -225,9 +221,6 @@ class XGrid(BaseGrid):
             _ = self.xgcm_grid.axes["Y"]
         except KeyError:
             return np.zeros(1)
-        # ensure lat is loaded into memory for dask-backed datasets, as it is used in the search method
-        if is_dask_collection(self._ds["lat"].data):
-            self._ds["lat"].load()
         return self._ds["lat"].values
 
     @property

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -200,7 +200,7 @@ class _FieldSetDescriptionRow:
             "Type": self.type_,
             "Grid number": str(self.model_id) if self.model_id is not None else "-",
             "Interp method / value": self.interp_method_or_value,
-            "Backend": self.backend if self.backend is not None else "-",
+            "Parcels backend": self.backend if self.backend is not None else "-",
         }
 
 

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import xarray as xr
+import zarr
 from dask.base import is_dask_collection
 
 from parcels._core._windowed_array import WindowedArray
@@ -223,6 +224,8 @@ def _field_backend(field: Field | VectorField) -> str | None:
             return "WindowedArray"
         elif is_dask_collection(field.data.data):
             return "Dask"
+        elif isinstance(field.data.variable._data, zarr.Array):
+            return "Zarr"
         elif isinstance(field.data.data, np.ndarray):
             return "NumPy"
         else:

--- a/src/parcels/_reprs.py
+++ b/src/parcels/_reprs.py
@@ -8,7 +8,9 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import xarray as xr
+from dask.base import is_dask_collection
 
+from parcels._core._windowed_array import WindowedArray
 from parcels._python import isinstance_noimport
 
 if TYPE_CHECKING:
@@ -190,6 +192,7 @@ class _FieldSetDescriptionRow:
     model_id: int | None
     name: str
     interp_method_or_value: str
+    backend: str | None = None
 
     def to_dict(self) -> dict[str, str]:
         return {
@@ -197,6 +200,7 @@ class _FieldSetDescriptionRow:
             "Type": self.type_,
             "Grid number": str(self.model_id) if self.model_id is not None else "-",
             "Interp method / value": self.interp_method_or_value,
+            "Backend": self.backend if self.backend is not None else "-",
         }
 
 
@@ -211,6 +215,20 @@ def _print_time_interval(time_interval: TimeInterval | None) -> str:
     if time_interval is None:
         return repr(time_interval)
     return repr((time_interval.left, time_interval.right))
+
+
+def _field_backend(field: Field | VectorField) -> str | None:
+    if hasattr(field, "data"):
+        if isinstance(field.data, WindowedArray):
+            return "WindowedArray"
+        elif is_dask_collection(field.data.data):
+            return "Dask"
+        elif isinstance(field.data.data, np.ndarray):
+            return "NumPy"
+        else:
+            return type(field.data).__name__
+    else:
+        return None
 
 
 def fieldset_describe(fieldset: FieldSet) -> str:
@@ -235,6 +253,7 @@ def fieldset_describe(fieldset: FieldSet) -> str:
                 model_id=model_id,
                 name=field.name,
                 interp_method_or_value=repr(field.interp_method),
+                backend=_field_backend(field),
             )
         )
     for k, v in fieldset.context.items():
@@ -244,6 +263,7 @@ def fieldset_describe(fieldset: FieldSet) -> str:
                 model_id=None,
                 name=k,
                 interp_method_or_value=repr(v),
+                backend=None,
             )
         )
     return (

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import parcels.tutorial
 from parcels import Field, ParticleFile, ParticleSet, XGrid, convert
 from parcels._core.fieldset import FieldSet, _datetime_to_msg
 from parcels._core.model import _default_vector_field_components
@@ -398,20 +399,70 @@ def test_fieldset_describe(fieldset_two_models: FieldSet):
     fieldset = fieldset_two_models
     io = StringIO()
     expected = """\
-| Name           | Type        | Grid number   | Interp method / value   |
-|:---------------|:------------|:--------------|:------------------------|
-| my_list        | Context     | -             | [1, 2, 'hello']         |
-| my_value       | Context     | -             | 2.0                     |
-| U              | Field       | 0             | XLinear(...)            |
-| V              | Field       | 0             | XLinear(...)            |
-| UV             | VectorField | 0             | XLinear_Velocity(...)   |
-| U_wind         | Field       | 1             | XLinear(...)            |
-| V_wind         | Field       | 1             | XLinear(...)            |
-| UV_wind        | VectorField | 1             | XLinear_Velocity(...)   |
-| constant_field | Field       | 2             | XConstantField(...)     |
+| Name           | Type        | Grid number   | Interp method / value   | Backend   |
+|:---------------|:------------|:--------------|:------------------------|:----------|
+| my_list        | Context     | -             | [1, 2, 'hello']         | -         |
+| my_value       | Context     | -             | 2.0                     | -         |
+| U              | Field       | 0             | XLinear(...)            | NumPy     |
+| V              | Field       | 0             | XLinear(...)            | NumPy     |
+| UV             | VectorField | 0             | XLinear_Velocity(...)   | -         |
+| U_wind         | Field       | 1             | XLinear(...)            | NumPy     |
+| V_wind         | Field       | 1             | XLinear(...)            | NumPy     |
+| UV_wind        | VectorField | 1             | XLinear_Velocity(...)   | -         |
+| constant_field | Field       | 2             | XConstantField(...)     | NumPy     |
 
 mesh: flat
 time interval: (np.datetime64('2000-01-01T00:00:00.000000000'), np.datetime64('2001-01-01T00:00:00.000000000'))
+"""
+    fieldset.describe(io)
+    actual = io.getvalue()
+    assert actual == expected
+
+
+def test_fieldset_describe_backends():
+    ds_u = parcels.tutorial.open_dataset("NemoNorthSeaORCA025-N006_data/U")
+    ds_v = parcels.tutorial.open_dataset("NemoNorthSeaORCA025-N006_data/V")
+    ds_w = parcels.tutorial.open_dataset("NemoNorthSeaORCA025-N006_data/W")
+    ds_coords = parcels.tutorial.open_dataset("NemoNorthSeaORCA025-N006_data/mesh_mask")[["glamf", "gphif"]]
+
+    ds_fset = convert.nemo_to_sgrid(
+        fields={"U": ds_u["uo"], "V": ds_v["vo"], "W": ds_w["wo"]},
+        coords=ds_coords,
+    )
+    fieldset = FieldSet.from_sgrid_conventions(ds_fset)
+
+    io = StringIO()
+    expected = """\
+| Name   | Type        |   Grid number | Interp method / value   | Backend   |
+|:-------|:------------|--------------:|:------------------------|:----------|
+| U      | Field       |             0 | XLinear(...)            | Dask      |
+| V      | Field       |             0 | XLinear(...)            | Dask      |
+| W      | Field       |             0 | XLinear(...)            | Dask      |
+| UV     | VectorField |             0 | CGrid_Velocity(...)     | -         |
+| UVW    | VectorField |             0 | CGrid_Velocity(...)     | -         |
+
+mesh: spherical
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
+"""
+    fieldset.describe(io)
+    actual = io.getvalue()
+    assert actual == expected
+
+    # Also run with WindowedArray backend
+    fieldset = fieldset.to_windowed_arrays()
+
+    io = StringIO()
+    expected = """\
+| Name   | Type        |   Grid number | Interp method / value   | Backend       |
+|:-------|:------------|--------------:|:------------------------|:--------------|
+| U      | Field       |             0 | XLinear(...)            | WindowedArray |
+| V      | Field       |             0 | XLinear(...)            | WindowedArray |
+| W      | Field       |             0 | XLinear(...)            | WindowedArray |
+| UV     | VectorField |             0 | CGrid_Velocity(...)     | -             |
+| UVW    | VectorField |             0 | CGrid_Velocity(...)     | -             |
+
+mesh: spherical
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
 """
     fieldset.describe(io)
     actual = io.getvalue()

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -431,7 +431,6 @@ def test_fieldset_describe_backends(tmp_path):
         coords=ds_coords,
     )
     fieldset = FieldSet.from_sgrid_conventions(ds_fset)
-    print(fieldset.describe())
 
     io = StringIO()
     expected = """\
@@ -444,7 +443,7 @@ def test_fieldset_describe_backends(tmp_path):
 | UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: spherical
-time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-12T12:00:00.000000000'))
 """
     fieldset.describe(io)
     actual = io.getvalue()
@@ -452,7 +451,6 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
 
     # Also run with WindowedArray backend
     fieldset = fieldset.to_windowed_arrays()
-    print(fieldset.describe())
 
     io = StringIO()
     expected = """\
@@ -465,7 +463,7 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
 | UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: spherical
-time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-12T12:00:00.000000000'))
 """
     fieldset.describe(io)
     actual = io.getvalue()
@@ -475,7 +473,6 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
     ds_fset.to_zarr(path)
     ds_zarr = open_raw_zarr(path)
     fieldset = FieldSet.from_sgrid_conventions(ds_zarr)
-    print(fieldset.describe())
 
     io = StringIO()
     expected = """\
@@ -488,7 +485,7 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
 | UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: spherical
-time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-12T12:00:00.000000000'))
 """
     fieldset.describe(io)
     actual = io.getvalue()

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -431,6 +431,7 @@ def test_fieldset_describe_backends(tmp_path):
         coords=ds_coords,
     )
     fieldset = FieldSet.from_sgrid_conventions(ds_fset)
+    print(fieldset.describe())
 
     io = StringIO()
     expected = """\
@@ -451,6 +452,7 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
 
     # Also run with WindowedArray backend
     fieldset = fieldset.to_windowed_arrays()
+    print(fieldset.describe())
 
     io = StringIO()
     expected = """\
@@ -473,6 +475,8 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
     ds_fset.to_zarr(path)
     ds_zarr = open_raw_zarr(path)
     fieldset = FieldSet.from_sgrid_conventions(ds_zarr)
+    print(fieldset.describe())
+
     io = StringIO()
     expected = """\
 | Name   | Type        |   Grid number | Interp method / value   | Parcels backend   |

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 import parcels.tutorial
-from parcels import Field, ParticleFile, ParticleSet, XGrid, convert
+from parcels import Field, ParticleFile, ParticleSet, XGrid, convert, open_raw_zarr
 from parcels._core.fieldset import FieldSet, _datetime_to_msg
 from parcels._core.model import _default_vector_field_components
 from parcels._datasets.structured.generic import datasets as datasets_structured
@@ -420,7 +420,7 @@ time interval: (np.datetime64('2000-01-01T00:00:00.000000000'), np.datetime64('2
     assert actual == expected
 
 
-def test_fieldset_describe_backends():
+def test_fieldset_describe_backends(tmp_path):
     ds_u = parcels.tutorial.open_dataset("NemoNorthSeaORCA025-N006_data/U")
     ds_v = parcels.tutorial.open_dataset("NemoNorthSeaORCA025-N006_data/V")
     ds_w = parcels.tutorial.open_dataset("NemoNorthSeaORCA025-N006_data/W")
@@ -459,6 +459,27 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
 | U      | Field       |             0 | XLinear(...)            | WindowedArray     |
 | V      | Field       |             0 | XLinear(...)            | WindowedArray     |
 | W      | Field       |             0 | XLinear(...)            | WindowedArray     |
+| UV     | VectorField |             0 | CGrid_Velocity(...)     | -                 |
+| UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
+
+mesh: spherical
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
+"""
+    fieldset.describe(io)
+    actual = io.getvalue()
+    assert actual == expected
+
+    path = tmp_path / "ds.zarr"
+    ds_fset.to_zarr(path)
+    ds_zarr = open_raw_zarr(path)
+    fieldset = FieldSet.from_sgrid_conventions(ds_zarr)
+    io = StringIO()
+    expected = """\
+| Name   | Type        |   Grid number | Interp method / value   | Parcels backend   |
+|:-------|:------------|--------------:|:------------------------|:------------------|
+| U      | Field       |             0 | XLinear(...)            | Zarr              |
+| V      | Field       |             0 | XLinear(...)            | Zarr              |
+| W      | Field       |             0 | XLinear(...)            | Zarr              |
 | UV     | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 | UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -400,16 +400,17 @@ def test_fieldset_describe(fieldset_two_models: FieldSet):
     io = StringIO()
     expected = """\
 | Name           | Type        | Grid number   | Interp method / value   | Backend   |
-|:---------------|:------------|:--------------|:------------------------|:----------|
-| my_list        | Context     | -             | [1, 2, 'hello']         | -         |
-| my_value       | Context     | -             | 2.0                     | -         |
-| U              | Field       | 0             | XLinear(...)            | NumPy     |
-| V              | Field       | 0             | XLinear(...)            | NumPy     |
-| UV             | VectorField | 0             | XLinear_Velocity(...)   | -         |
-| U_wind         | Field       | 1             | XLinear(...)            | NumPy     |
-| V_wind         | Field       | 1             | XLinear(...)            | NumPy     |
-| UV_wind        | VectorField | 1             | XLinear_Velocity(...)   | -         |
-| constant_field | Field       | 2             | XConstantField(...)     | NumPy     |
+| Name           | Type        | Grid number   | Interp method / value   | Parcels backend   |
+|:---------------|:------------|:--------------|:------------------------|:------------------|
+| my_list        | Context     | -             | [1, 2, 'hello']         | -                 |
+| my_value       | Context     | -             | 2.0                     | -                 |
+| U              | Field       | 0             | XLinear(...)            | NumPy             |
+| V              | Field       | 0             | XLinear(...)            | NumPy             |
+| UV             | VectorField | 0             | XLinear_Velocity(...)   | -                 |
+| U_wind         | Field       | 1             | XLinear(...)            | NumPy             |
+| V_wind         | Field       | 1             | XLinear(...)            | NumPy             |
+| UV_wind        | VectorField | 1             | XLinear_Velocity(...)   | -                 |
+| constant_field | Field       | 2             | XConstantField(...)     | NumPy             |
 
 mesh: flat
 time interval: (np.datetime64('2000-01-01T00:00:00.000000000'), np.datetime64('2001-01-01T00:00:00.000000000'))
@@ -433,13 +434,13 @@ def test_fieldset_describe_backends():
 
     io = StringIO()
     expected = """\
-| Name   | Type        |   Grid number | Interp method / value   | Backend   |
-|:-------|:------------|--------------:|:------------------------|:----------|
-| U      | Field       |             0 | XLinear(...)            | Dask      |
-| V      | Field       |             0 | XLinear(...)            | Dask      |
-| W      | Field       |             0 | XLinear(...)            | Dask      |
-| UV     | VectorField |             0 | CGrid_Velocity(...)     | -         |
-| UVW    | VectorField |             0 | CGrid_Velocity(...)     | -         |
+| Name   | Type        |   Grid number | Interp method / value   | Parcels backend   |
+|:-------|:------------|--------------:|:------------------------|:------------------|
+| U      | Field       |             0 | XLinear(...)            | Dask              |
+| V      | Field       |             0 | XLinear(...)            | Dask              |
+| W      | Field       |             0 | XLinear(...)            | Dask              |
+| UV     | VectorField |             0 | CGrid_Velocity(...)     | -                 |
+| UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: spherical
 time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
@@ -453,13 +454,13 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
 
     io = StringIO()
     expected = """\
-| Name   | Type        |   Grid number | Interp method / value   | Backend       |
-|:-------|:------------|--------------:|:------------------------|:--------------|
-| U      | Field       |             0 | XLinear(...)            | WindowedArray |
-| V      | Field       |             0 | XLinear(...)            | WindowedArray |
-| W      | Field       |             0 | XLinear(...)            | WindowedArray |
-| UV     | VectorField |             0 | CGrid_Velocity(...)     | -             |
-| UVW    | VectorField |             0 | CGrid_Velocity(...)     | -             |
+| Name   | Type        |   Grid number | Interp method / value   | Parcels backend   |
+|:-------|:------------|--------------:|:------------------------|:------------------|
+| U      | Field       |             0 | XLinear(...)            | WindowedArray     |
+| V      | Field       |             0 | XLinear(...)            | WindowedArray     |
+| W      | Field       |             0 | XLinear(...)            | WindowedArray     |
+| UV     | VectorField |             0 | CGrid_Velocity(...)     | -                 |
+| UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: spherical
 time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))


### PR DESCRIPTION
### Description

This PR fixes #2751, by calling a `.compute()` on variables that have a `mockT` dimension (i.e. no time), thereby speeding up the `fieldset.to_windowed_arrays()` method.

It also loads `lon` and `lat` explicitly, which are not dimensions but variables in a curvilinear grid.

Finally, it adds information about rhetorical backend (Numpy, Dask or WindowedArray) to each field in `fieldset.describe()`

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2751
- [ ] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None