### PR TITLE
Fix loading dimensions on ugrids for WindowedArrays

### DIFF
--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -103,12 +103,10 @@ class ModelData(ABC):
             and ``max_levels`` then bounds its size.
         """
         windowed = self.__dict__.setdefault("_windowed", {})
-        for dim in ["lon", "lat"]:
-            # ensure lon and lat are loaded into memory for dask-backed datasets
+        for dim in ["lon", "lat", "depth"]:
+            # ensure lon, lat, depth are loaded into memory for dask-backed datasets
             if dim in self.data and is_dask_collection(self.data[dim]):
                 self.data[dim].load()
-        if "depth" in self.data.dims and is_dask_collection(self.data["depth"]):
-            self.data["depth"].load()
         for name in self.scalar_field_names:
             current = windowed.get(name, self.data[name])
             windowed[name] = maybe_windowed(current, max_levels=max_levels)

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -105,7 +105,7 @@ class ModelData(ABC):
         windowed = self.__dict__.setdefault("_windowed", {})
         for dim in ["lon", "lat"]:
             # ensure lon and lat are loaded into memory for dask-backed datasets
-            if is_dask_collection(self.data[dim]):
+            if dim in self.data and is_dask_collection(self.data[dim]):
                 self.data[dim].load()
         if "depth" in self.data.dims and is_dask_collection(self.data["depth"]):
             self.data["depth"].load()


### PR DESCRIPTION
### Description

Yesterday I implemented explicit loading of lon/lat and (if available) depth in `to_windowed_arrays()` in #2752; but I now realise that this breaks for Grids - because these don't have lon and lat. This PR fixes that

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2757
- [ ] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None
