### PR TITLE
Fix progress output in non-interactive shells

### DIFF
--- a/src/parcels/_core/particleset.py
+++ b/src/parcels/_core/particleset.py
@@ -420,6 +420,7 @@ class ParticleSet:
             pbar = tqdm(
                 total=sign_dt * (end_time - start_time),
                 file=sys.stdout,
+                disable=None,
                 bar_format="{desc} {percentage:3.0f}%|{bar}| [{elapsed}<{remaining}, {rate_fmt}]",
             )
             pbar.set_description_str(

--- a/tests/test_particleset.py
+++ b/tests/test_particleset.py
@@ -1,3 +1,4 @@
+import sys
 from contextlib import nullcontext as does_not_raise
 from datetime import datetime, timedelta
 from operator import attrgetter
@@ -31,6 +32,23 @@ def test_create_empty_pset(fieldset):
 
     pset.execute(DoNothing, endtime=1.0, dt=1.0)
     assert pset.size == 0
+
+
+@pytest.mark.parametrize(
+    ("is_tty", "expect_progress"),
+    [(True, True), (False, False)],
+)
+def test_pset_execute_progress_respects_stdout_tty(fieldset, monkeypatch, capsys, is_tty, expect_progress):
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: is_tty)
+    pset = ParticleSet(fieldset, x=0, y=0, pclass=Particle)
+
+    pset.execute(
+        DoNothing,
+        runtime=np.timedelta64(1, "s"),
+        dt=np.timedelta64(1, "s"),
+    )
+
+    assert bool(capsys.readouterr().out) is expect_progress
 
 
 @pytest.mark.parametrize("offset", [0, 1, 200])


### PR DESCRIPTION
### Description

Adds automatic TTY detection to the `ParticleSet.execute` progress bar.

Passing `disable=None` to `tqdm` preserves the progress bar in interactive terminals while suppressing it when stdout is redirected to a non-interactive environment, such as a Slurm job log.

The added regression test verifies both interactive and non-interactive stdout behavior without depending on exact progress-bar formatting.

### Validation

* `pixi run pytest tests/test_particleset.py -q`

  * 26 passed
* `pixi run lint`

  * All hooks passed
* `pixi run typing`

  * Success: no issues found in 41 source files
* `git diff --check`

  * Passed

### Checklist

* [x] Closes #2673
* [x] Tests added
* [x] This PR targets `main`

### AI Disclosure

* [x] This PR contains AI-generated content.

  * [x] I have tested any AI-generated content in my PR.
  * [x] I take responsibility for any AI-generated content in my PR.
  * I used Codex to inspect the relevant code, propose the minimal implementation, and help design the regression test. I manually reviewed and understood every changed line and ran the project’s test, lint, and typing checks.

[This draft pull request was opened by Codex on behalf of @aryasalem09.]
