### PR TITLE
Adds a warning whenever a _mesh is different for a field when added to a FieldSet, or during Fieldset creation

### DIFF
--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -219,7 +219,7 @@ class FieldSet:
         self.reconstruct_fields()
         field = getattr(self, name)
         field.interp_method = XConstantField()
-        _warn_if_fields_use_different_meshes(self.fields.values())
+        #_warn_if_fields_use_different_meshes(self.fields.values())
 
     def add_context(self, name, value):
         """Add context variable to the FieldSet.

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import sys
+import warnings
 from collections.abc import Iterable
 from typing import IO, TYPE_CHECKING
 
@@ -21,6 +22,7 @@ from parcels._core.model import (
 from parcels._core.utils.string import _assert_str_and_python_varname
 from parcels._core.utils.time import get_datetime_type_calendar
 from parcels._core.utils.time import is_compatible as datetime_is_compatible
+from parcels._core.warnings import FieldSetWarning
 from parcels._python import NOTSET, NotSetType
 from parcels._reprs import fieldset_describe
 from parcels.interpolators import (
@@ -73,6 +75,7 @@ class FieldSet:
         self._fields: dict[str, Field | VectorField] | None = None
         self.reconstruct_fields()
         self.context: dict[str, float] = {}
+        _warn_if_fields_use_different_meshes(self.fields.values())
 
     def __setattr__(self, name, value):
         """Set field attribute by name. If context exists and name in context, raise error to prevent overwriting context variable."""
@@ -151,6 +154,7 @@ class FieldSet:
             raise ValueError(f"FieldSet already has a Field with name '{name}'")
 
         self.fields[name] = field
+        _warn_if_fields_use_different_meshes(self.fields.values())
 
     def to_windowed_arrays(self, *, max_levels: int | None = None):
         """Wrap dask-backed field data in rolling time-window caches.
@@ -215,6 +219,7 @@ class FieldSet:
         self.reconstruct_fields()
         field = getattr(self, name)
         field.interp_method = XConstantField()
+        _warn_if_fields_use_different_meshes(self.fields.values())
 
     def add_context(self, name, value):
         """Add context variable to the FieldSet.
@@ -359,6 +364,28 @@ def assert_compatible_fieldsets(left: FieldSet, right: FieldSet) -> None:
     if common_context:
         raise ValueError(
             f"Cannot add FieldSets that have context value names in common. Duplicate context value names are: {sorted(common_context)}"
+        )
+
+
+def _warn_if_fields_use_different_meshes(fields: Iterable[Field | VectorField]):
+    """Warn if multiple fields use different meshes on the underlying grids.
+
+    Parameters
+    ----------
+    fields : Iterable[Field | VectorField]
+        The fields to check for conflicting meshes.
+
+    Warns
+    ------
+    FieldSetWarning
+        If the fields have different meshes on the underlying grids.
+    """
+    meshes = {field.grid._mesh for field in fields}
+    if len(meshes) > 1:
+        warnings.warn(
+            f"FieldSet has multiple different meshes: {meshes}. This may lead to unexpected behavior during execution.",
+            category=FieldSetWarning,
+            stacklevel=2,
         )
 
 

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -219,7 +219,7 @@ class FieldSet:
         self.reconstruct_fields()
         field = getattr(self, name)
         field.interp_method = XConstantField()
-        #_warn_if_fields_use_different_meshes(self.fields.values())
+        # _warn_if_fields_use_different_meshes(self.fields.values())
 
     def add_context(self, name, value):
         """Add context variable to the FieldSet.
@@ -376,7 +376,7 @@ def _warn_if_fields_use_different_meshes(fields: Iterable[Field | VectorField]):
         The fields to check for conflicting meshes.
 
     Warns
-    ------
+    -----
     FieldSetWarning
         If the fields have different meshes on the underlying grids.
     """

--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -219,7 +219,7 @@ class FieldSet:
         self.reconstruct_fields()
         field = getattr(self, name)
         field.interp_method = XConstantField()
-        # _warn_if_fields_use_different_meshes(self.fields.values())
+        _warn_if_fields_use_different_meshes(self.fields.values())
 
     def add_context(self, name, value):
         """Add context variable to the FieldSet.
@@ -385,7 +385,7 @@ def _warn_if_fields_use_different_meshes(fields: Iterable[Field | VectorField]):
         warnings.warn(
             f"FieldSet has multiple different meshes: {meshes}. This may lead to unexpected behavior during execution.",
             category=FieldSetWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
 
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -31,7 +31,7 @@ def fieldset_two_models():
     fset2 = FieldSet.from_sgrid_conventions(ds2, mesh="flat", vector_fields={"UV_wind": ("U_wind", "V_wind")})
     fset2.add_context("my_value", 2.0)
     fset2.add_context("my_list", [1, 2, "hello"])
-    fset2.add_constant_field("constant_field", 3.0)
+    fset2.add_constant_field("constant_field", 3.0, mesh="flat")
     return fset1 + fset2
 
 
@@ -68,7 +68,7 @@ def test_fieldset_add_context_invalid_name(fieldset, name):
 
 
 def test_fieldset_add_constant_field(fieldset):
-    fieldset.add_constant_field("test_constant_field", 1.0)
+    fieldset.add_constant_field("test_constant_field", 1.0, mesh="flat")
 
     # Get a point in the domain
     time = ds["time"].mean()
@@ -85,7 +85,7 @@ def test_fieldset_gridset(fieldset):
     assert fieldset.fields["UV"].grid in fieldset.gridset
     assert len(fieldset.gridset) == 1
 
-    fieldset.add_constant_field("constant_field", 1.0)
+    fieldset.add_constant_field("constant_field", 1.0, mesh="flat")
     assert len(fieldset.gridset) == 2
 
 
@@ -232,7 +232,7 @@ def test_fieldset_time_interval():
     field2 = Field("field2", ds2["U_A_grid"], grid2, interp_method=XLinear)
 
     fieldset = FieldSet([field1, field2])
-    fieldset.add_constant_field("constant_field", 1.0)
+    fieldset.add_constant_field("constant_field", 1.0, mesh="flat")
 
     assert fieldset.time_interval.left == np.datetime64("2000-01-02")
     assert fieldset.time_interval.right == np.datetime64("2001-01-01")


### PR DESCRIPTION
### Description
Currently, mixing `"flat"` and `"spherical"` meshes in a FieldSet is allowed without warning. This can happen without intention whenever a field is created with the default mesh, which may not be the same mesh as underlies the rest of the FieldSet. This PR adds a function `_warn_if_fields_use_different_meshes(fields: Iterable[Field | VectorField])` in `fieldset.py` which produces a `FieldSetWarning` if fields in the input iterable have different _mesh in their underlying grid. A call to the function is also added at the end of` FieldSet.__init__` and `FieldSet.add_field`
### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2190 
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt): I used Claude Code in plan mode to help understand relevant parts of the code base. All code was written by myself.
