### PR TITLE
MAINT: Bump Pixi version and unpin XGCM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,6 @@ jobs:
           persist-credentials: false
       - uses: Parcels-code/pixi-lock/create-and-cache@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
         id: pixi-lock
-        with:
-          pixi-version: v0.70.2
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pixi-lock

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,8 +7,8 @@ build:
   jobs:
     create_environment:
       - asdf plugin add pixi
-      - asdf install pixi 0.70.2
-      - asdf global pixi 0.70.2
+      - asdf install pixi latest
+      - asdf global pixi latest
     install:
       - pixi install -e docs
     build:

--- a/pixi.toml
+++ b/pixi.toml
@@ -61,7 +61,7 @@ pyarrow = "20.0.*"
 uxarray = "==2026.04.1"
 dask = "2024.6.*"
 zarr = "3.0.*"
-xgcm = { version = "0.9.*", channel = "conda-forge" }
+xgcm = { git = "https://github.com/xgcm/xgcm", rev = "master" } # TODO: Switch to release version after release is cut
 cf_xarray = "0.10.*"
 cftime = "1.6.*"
 pooch = "1.8.*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,14 +4,14 @@ exclude-newer = "5d" # security pre-caution against compromised packages
 preview = ["pixi-build"]
 channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
-requires-pixi = ">=0.67.0,!=0.68.0,<0.71.0"
+requires-pixi = ">=0.72.0"
 
 [package]
 name = "parcels"
 version = "dynamic" # dynamic versioning needs better support in pixi https://github.com/prefix-dev/pixi/issues/2923#issuecomment-2598460666 . Putting `version = "dynamic"` here for now until pixi recommends something else.
 
 [package.build]
-backend = { name = "pixi-build-python", version = "0.4.*" }
+backend = { name = "pixi-build-python", version = "0.7.*" }
 
 [package.host-dependencies]
 setuptools = "*"
@@ -30,7 +30,7 @@ holoviews = ">=1.22.0" # https://github.com/prefix-dev/rattler-build/issues/2326
 uxarray = ">=2026.04.1"
 dask = ">=2024.5.1"
 zarr = ">=3"
-xgcm = { git = "https://github.com/xgcm/xgcm", rev = "532a3c567c475cbe192f49b9961f8117806bbfb7" } # TODO: Switch to release version after release is cut
+xgcm = { git = "https://github.com/xgcm/xgcm", rev = "master" } # TODO: Switch to release version after release is cut
 cf_xarray = ">=0.8.6"
 cftime = ">=1.6.3"
 pooch = ">=1.8.0"

--- a/src/parcels/_core/xgrid.py
+++ b/src/parcels/_core/xgrid.py
@@ -1,7 +1,7 @@
 from collections.abc import Hashable, Sequence
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -17,20 +17,23 @@ from parcels._core.mesh import SphericalMesh, get_mesh
 from parcels._sgrid.accessor import _get_dim_to_axis_mapping
 from parcels._sgrid.core import SGRID_PADDING_TO_XGCM_POSITION
 
+if TYPE_CHECKING:
+    import xgcm.axis
+
 _FIELD_DATA_ORDERING: Sequence[ptyping.XgcmAxisDirection] = "TZYX"
 _XGRID_AXES_ORDERING: Sequence[ptyping.XgridAxis] = "ZYX"
 
 _DEFAULT_XGCM_KWARGS: dict[str, Any] = {"padding": "fill"}
 
 
-def get_cell_count_along_dim(ds: xr.Dataset, axis: xgcm.Axis) -> int:
+def get_cell_count_along_dim(ds: xr.Dataset, axis: xgcm.axis.Axis) -> int:
     first_coord = list(axis.coords.items())[0]
     _, coord_var = first_coord
 
     return ds[coord_var].size - 1
 
 
-def get_time(ds: xr.Dataset, axis: xgcm.Axis) -> npt.NDArray:
+def get_time(ds: xr.Dataset, axis: xgcm.axis.Axis) -> npt.NDArray:
     return ds[axis.coords["center"]].values
 
 

--- a/src/parcels/_core/xgrid.py
+++ b/src/parcels/_core/xgrid.py
@@ -20,7 +20,7 @@ from parcels._sgrid.core import SGRID_PADDING_TO_XGCM_POSITION
 _FIELD_DATA_ORDERING: Sequence[ptyping.XgcmAxisDirection] = "TZYX"
 _XGRID_AXES_ORDERING: Sequence[ptyping.XgridAxis] = "ZYX"
 
-_DEFAULT_XGCM_KWARGS: dict[str, Any] = {"periodic": False}
+_DEFAULT_XGCM_KWARGS: dict[str, Any] = {"padding": "fill"}
 
 
 def get_cell_count_along_dim(ds: xr.Dataset, axis: xgcm.Axis) -> int:


### PR DESCRIPTION
### Description

Now that https://github.com/xgcm/xgcm/pull/739 is merged, we can unpin Pixi and xgcm.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None used