### PR TITLE
Fix hashtable.query by checking for both roots in index_search

### DIFF
--- a/src/parcels/_core/index_search.py
+++ b/src/parcels/_core/index_search.py
@@ -139,13 +139,49 @@ def _bilinear_inverse(px, py, xq, yq):
     det2 = bb * bb - 4 * aa * cc
 
     with np.errstate(divide="ignore", invalid="ignore"):
-        det = np.where(det2 > 0, np.sqrt(det2), eta_init)
-        eta = np.where(abs(aa) < 1e-12, -cc / bb, np.where(det2 > 0, (-bb + det) / (2 * aa), eta_init))
-        xsi = np.where(
-            abs(a[1] + a[3] * eta) < 1e-12,
-            ((yq - py[0]) / (py[1] - py[0]) + (yq - py[3]) / (py[2] - py[3])) * 0.5,
-            (xq - a[0] - a[2] * eta) / (a[1] + a[3] * eta),
+        det = np.where(det2 >= 0, np.sqrt(det2), np.nan)
+        eta_plus = (-bb + det) / (2 * aa)
+        eta_minus = (-bb - det) / (2 * aa)
+
+        def _compute_xsi(eta):
+            return np.where(
+                abs(a[1] + a[3] * eta) < 1e-12,
+                ((yq - py[0]) / (py[1] - py[0]) + (yq - py[3]) / (py[2] - py[3])) * 0.5,
+                (xq - a[0] - a[2] * eta) / (a[1] + a[3] * eta),
+            )
+
+        xsi_plus = _compute_xsi(eta_plus)
+        xsi_minus = _compute_xsi(eta_minus)
+
+        tol = 1e-10
+        valid_plus = (
+            np.isfinite(xsi_plus)
+            & np.isfinite(eta_plus)
+            & (xsi_plus >= -tol)
+            & (xsi_plus <= 1 + tol)
+            & (eta_plus >= -tol)
+            & (eta_plus <= 1 + tol)
         )
+        valid_minus = (
+            np.isfinite(xsi_minus)
+            & np.isfinite(eta_minus)
+            & (xsi_minus >= -tol)
+            & (xsi_minus <= 1 + tol)
+            & (eta_minus >= -tol)
+            & (eta_minus <= 1 + tol)
+        )
+
+        eta = np.where(valid_plus, eta_plus, np.where(valid_minus, eta_minus, eta_plus))
+        xsi = np.where(valid_plus, xsi_plus, np.where(valid_minus, xsi_minus, xsi_plus))
+
+        linear = abs(aa) < 1e-12
+        eta_linear = -cc / bb
+        xsi_linear = _compute_xsi(eta_linear)
+        eta = np.where(linear, eta_linear, eta)
+        xsi = np.where(linear, xsi_linear, xsi)
+
+    eta = np.where(np.isfinite(eta), eta, eta_init)
+    xsi = np.where(np.isfinite(xsi), xsi, eta_init)
     return xsi, eta
 
 


### PR DESCRIPTION
### Description

While working on the Delft3D with NaNs for lon//lat, I realised that the issue wasn't the creation of the hashtable itself (that works fine with NaNs for lon/lat points), but that the point-in-cell test always returned False, even if a point was clearly in a cell.

After some further digging, I discovered that the issue was in `index_search._bilinear_inverse()`, which did not return the correct barycentric coordinates

With some help from an LLM (see prompt below), I then found the issue and a solution:

The function produces two quadratic roots for eta, but the current implementation always selects the 
`(−bb+det)/(2a)` solution. It should of course also check the `(−bb-det)/(2a)` solution.

This PR implements that. And now the hashtable search works on the Delft3D grid!

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None
- [ ] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt):

"I use the _bilinear_inverse function here to find out the baricentric coordinates of a point_in_cell check. However, it does not seem to be working because if I input px: [[39878.2421875 39849.01953125 39819.69921875 39790.2734375 ]
[40011.484375 39982.2109375 39952.8359375 39923.3515625 ]
[39982.2109375 39952.8359375 39923.3515625 39893.75 ]
[39849.01953125 39819.69921875 39790.2734375 39760.71875 ]], py: [[450116.90625 450081.46875 450045.90625 450010.3125 ]
[450014.3125 449978.875 449943.3125 449907.6875 ]
[449978.875 449943.3125 449907.6875 449871.90625]
[450081.46875 450045.90625 450010.3125 449974.5625 ]], xq: [39900. 39900. 39900. 39900.], yq: [450000. 450000. 450000. 450000.]
then I get xsi: [-1481.18252686 -1380.11892455 -762.69672299 -868.69661282], eta: [ 4291.41378809 3983.77629991 6657.93389165 10363.58362922], but none of these are between 0 and 1, as I would expect because the point lays within one of the cells"