### PR TITLE
Added .__eq__ and .__hash__ to BaseMesh

### DIFF
--- a/src/parcels/_core/mesh.py
+++ b/src/parcels/_core/mesh.py
@@ -12,6 +12,11 @@ class BaseMesh(ABC):
     @abstractmethod
     def is_spherical(self) -> bool: ...
 
+    def __eq__(self, other):
+        return self.is_spherical() == other.is_spherical() and self.radius == other.radius
+
+    def __hash__(self):
+        return hash((self.is_spherical(), self.radius))
 
 class SphericalMesh(BaseMesh):
     """Spherical mesh object with configurable planetary radius.

--- a/src/parcels/_core/mesh.py
+++ b/src/parcels/_core/mesh.py
@@ -18,6 +18,7 @@ class BaseMesh(ABC):
     def __hash__(self):
         return hash((self.is_spherical(), self.radius))
 
+
 class SphericalMesh(BaseMesh):
     """Spherical mesh object with configurable planetary radius.
 


### PR DESCRIPTION
### Description
After converting different mesh types to be classes in #2739 the hashing method used for identifying equal meshes breaks. The fix is to add .__eq__ and .__hash__ methods to the BaseMesh class. 
### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #2775 
- [ ] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt): I used claude code in plan mode to get information about how python's hash function hashes tuples. All code was written by myself.
