### PR TITLE
Add `convert` and `kernels` to parcels.__init__

### DIFF
--- a/src/parcels/__init__.py
+++ b/src/parcels/__init__.py
@@ -11,7 +11,6 @@ import warnings as _stdlib_warnings
 
 from parcels._core.fieldset import FieldSet
 from parcels._xarray import open_raw_zarr
-import parcels.convert  # noqa: F401
 from parcels._core.particleset import ParticleSet
 from parcels._core.particlefile import ParticleFile, read_particlefile
 from parcels._core.particle import (
@@ -39,8 +38,11 @@ from parcels._core.warnings import (
     FileWarning,
     KernelWarning,
     ParticleSetWarning,
+    FieldEvalWarning,
 )
 from parcels._logger import logger
+from . import convert
+from . import kernels
 
 __all__ = [  # noqa: RUF022
     # Core classes
@@ -72,9 +74,11 @@ __all__ = [  # noqa: RUF022
     "KernelWarning",
     "ParticleSetWarning",
     # Utilities
-    "convert",
     "logger",
     "read_particlefile",
+    "convert",
+    # kernels
+    "kernels",
 ]
 
 _stdlib_warnings.warn(

--- a/src/parcels/__init__.py
+++ b/src/parcels/__init__.py
@@ -11,6 +11,7 @@ import warnings as _stdlib_warnings
 
 from parcels._core.fieldset import FieldSet
 from parcels._xarray import open_raw_zarr
+import parcels.convert  # noqa: F401
 from parcels._core.particleset import ParticleSet
 from parcels._core.particlefile import ParticleFile, read_particlefile
 from parcels._core.particle import (
@@ -71,6 +72,7 @@ __all__ = [  # noqa: RUF022
     "KernelWarning",
     "ParticleSetWarning",
     # Utilities
+    "convert",
     "logger",
     "read_particlefile",
 ]


### PR DESCRIPTION
### Description

This PR fixes #2794 by explicitly adding the convert module to `src/parcels/__init__.py`. That fixed the issue with notebook rendering.

The question now is why `parcels.convert` did work before and why is then was suddenly broken...

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [X] Closes #2794 
- [X] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None