### PR TITLE
Fixes missassignment of n_faces and n_nodes in fesom_to_ugrid

### DIFF
--- a/src/parcels/convert.py
+++ b/src/parcels/convert.py
@@ -778,8 +778,8 @@ def fesom_to_ugrid(ds: ux.UxDataset) -> ux.UxDataset:
     Renames vertical dimensions:
     - nz -> zf (vertical layer faces/interfaces)
     - nz1 -> zc (vertical layer centers)
-    - nod2 -> n_face (face)
-    - elem -> n_node (node)
+    - nod2 -> n_node (node)
+    - elem -> n_face (face)
 
     Parameters
     ----------
@@ -802,7 +802,7 @@ def fesom_to_ugrid(ds: ux.UxDataset) -> ux.UxDataset:
     """
     ds = ds.copy()
 
-    for try_dim, target in [("nod2", "n_face"), ("elem", "n_node")]:
+    for try_dim, target in [("elem", "n_face"), ("nod2", "n_node")]:
         if try_dim in ds.dims:
             ds = ds.rename_dims({try_dim: target})
 


### PR DESCRIPTION
### Description
Previously, there was a bug in `fesom_to_ugrid` which mismatched the assignment of `n_node` and `n_face`. This PR resolves this issue thereby fixing downstream `IndexSearch` errors that occur during interpolation.
### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2809 
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.oceanparcels.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt): This bug was originally found by claude while working on a local copy of the parcels-benchmarks repo. I then verified it and provided the fix myself.
