### PR TITLE
Add .load() call on UxGrid.uxgrid.face_node_connectivity

### DIFF
--- a/src/parcels/_core/uxgrid.py
+++ b/src/parcels/_core/uxgrid.py
@@ -45,6 +45,7 @@ class UxGrid(BaseGrid):
         self.z = z
         self._mesh = get_mesh(mesh)
         self._spatialhash = None
+        self.uxgrid.face_node_connectivity.load()
 
     @property
     def depth(self):

--- a/src/parcels/_core/uxgrid.py
+++ b/src/parcels/_core/uxgrid.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 import numpy as np
 import uxarray as ux
+from dask import is_dask_collection
 
 from parcels._core.basegrid import BaseGrid
 from parcels._core.index_search import GRID_SEARCH_ERROR, _search_1d_array, uxgrid_point_in_cell
@@ -45,7 +46,8 @@ class UxGrid(BaseGrid):
         self.z = z
         self._mesh = get_mesh(mesh)
         self._spatialhash = None
-        self.uxgrid.face_node_connectivity.load()
+        if is_dask_collection(self.uxgrid.face_node_connectivity.data):
+            self.uxgrid.face_node_connectivity.load()
 
     @property
     def depth(self):


### PR DESCRIPTION
### Description
See #2815 for major details, this PR serves to decrease the number of `dask.compute` calls during particle-in-cell checks and during interpolation for unstructured grids by backing the `uxgrid.face_node_connectivity` array with numpy rather than leaving it lazy as a dask array. 
### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #2815 
- [ ] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)