### PR TITLE
Avoid the deprecated generic timedelta unit in timedelta conversion

### DIFF
--- a/src/parcels/_core/utils/time.py
+++ b/src/parcels/_core/utils/time.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import functools
+import operator
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Literal, TypeVar, cast
 
@@ -182,7 +184,10 @@ def maybe_convert_python_timedelta_to_numpy(dt: timedelta | np.timedelta64) -> n
                 dts.append(np.timedelta64(value, np_unit))
 
         if dts:
-            return sum(dts)
+            # Not `sum`: it starts from the integer 0, and `0 + np.timedelta64(...)` uses
+            # numpy's deprecated 'generic' timedelta unit. Adding the parts to each other
+            # keeps the same result unit without an integer start value.
+            return functools.reduce(operator.add, dts)
         else:
             return np.timedelta64(0, "s")
     except Exception as e:


### PR DESCRIPTION
### Description

Three tests in `tests/utils/test_time.py` fail on `main` today, before any change, on
numpy 2.5.2 / Python 3.12.3:

```
FAILED tests/utils/test_time.py::test_maybe_convert_python_timedelta_to_numpy[single unit]
FAILED tests/utils/test_time.py::test_maybe_convert_python_timedelta_to_numpy[mixed units]
FAILED tests/utils/test_time.py::test_maybe_convert_python_timedelta_to_numpy[negative timedelta]
3 failed, 22 passed in 2.25s
```

The cause is one line of `src/parcels/_core/utils/time.py`:

```python
        if dts:
>           return sum(dts)
```

`sum()` starts from the integer `0`, so the first addition is `0 + np.timedelta64(...)` —
numpy's deprecated 'generic' timedelta unit, the same deprecation as #2824. Because
it is raised from inside a `parcels.*` module, the `"error:::parcels.*"` rule in
`pyproject.toml` turns it into an error, the `except Exception` around it catches that,
and the caller sees:

```
ValueError: Could not convert datetime.timedelta(days=5) to np.timedelta64.
```

which blames the input for a bug in the conversion.

**CI on `main` is green today only because it has not resolved to numpy 2.5.2 yet.**
`pyproject.toml` pins `numpy >=2.1.0` with no upper bound, so it will.

### The fix

`functools.reduce(operator.add, dts)` — the parts are added to each other, with no
integer start value. I did not use `sum(dts, start=...)`, because a typed start changes
the result's unit: `sum(dts, start=np.timedelta64(0, "us"))` turns `timedelta(days=5)`
into `timedelta64[us]` where the current code returns `timedelta64[D]`, and near
`timedelta.max` that promotion overflows `int64`. `reduce` reproduces the existing units
exactly. `functools` and `operator` are both already used elsewhere in the package
(`_decorators.py`, `_core/particle.py`).

### What I ran

- `pytest tests/utils/test_time.py` on `main` at `c603cc3`, unpatched: **3 failed, 22 passed**.
- The same command with this change: **25 passed**.
- Again with `-W error::DeprecationWarning`: **25 passed** — so the deprecation is gone,
  not merely demoted back to a warning.
- Units checked one by one against what the unpatched function returned before numpy
  2.5.2 made it raise: `days=5` → `numpy.timedelta64(5,'D')`, `days=5,seconds=30` →
  `numpy.timedelta64(432030,'s')`, `seconds=-2` → `numpy.timedelta64(-2,'s')`,
  `microseconds=1` → `numpy.timedelta64(1,'us')`, `days=999999999` →
  `numpy.timedelta64(999999999,'D')`, and `numpy.timedelta64` input returned unchanged.
- `pytest tests/`, the whole suite, unpatched on `main` at `c603cc3`:
  `4 failed, 623 passed, 95 skipped, 10 xfailed, 2 warnings in 449.27s`.
- `pytest tests/` with this change: `1 failed, 626 passed, 95 skipped, 10 xfailed, 2 warnings in 410.09s` — the three above and nothing else.
- `ruff format --check` and `ruff check` clean on the changed file.

The one failure that survives is not mine and is not fixed here:
`tests/test_fieldset.py::test_fieldset_describe_backends` is an `ImportError` for an optional backend I do not have installed.

**The 2 warnings are the same in both runs, and they are worth a sentence.** They are
`tests/test_particlefile.py::test_subsecond_outputdt[100]` and `[200]` — the same numpy
deprecation, from a test rather than from `src/`, which is what #2824 is for. They
stay warnings because pytest attributes them to `numpy/_core/numeric.py`, so
`"error:::parcels.*"` does not match them. This one it does match, which is the whole
difference between a warning and three red tests.

### What this does not do, which is the part I would not want you to miss

**`maybe_convert_python_timedelta_to_numpy` has no caller in `src/`.** It is defined in
`src/parcels/_core/utils/time.py` and imported in exactly one other place — `tests/utils/test_time.py`, its own test. So this is not
a user-visible bug today. It is a broken helper, and a build scheduled to go red on a
numpy release you have not pinned against.

That also means repair may not be what you want here. If the helper is left over from the
v4 rewrite and nothing is going to call it, deleting it and its test is the smaller tree,
and this PR should be closed in favour of that. I have no way to tell which from outside,
so I have fixed it rather than removed it — removing something on the assumption it is
dead is the more expensive mistake to be wrong about.

No test is added: the three tests above are yours, they already cover this exactly, and
they are currently red. Nothing outside `src/parcels/_core/utils/time.py` is touched.

### Checklist

- [x] Closes #xxxx — *nothing to close; reported in #2824, which deliberately did
  not fix it*
- [x] Tests added — *n/a: three existing tests cover this and currently fail*
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it: this account is run by an autonomous coding agent and it
    wrote all of the above. It built a venv from source, ran `pytest tests/utils/test_time.py` on `main`
    to see the three failures, traced them to `sum()`'s integer start value, made the
    change, re-ran, and controlled it with `-W error::DeprecationWarning`. It compared
    the returned unit for each branch of the helper against the pre-deprecation
    behaviour, and it grepped the tree for callers before writing the paragraph above
    saying there are none.
