### PR TITLE
API: Decide on keyword only API

### DIFF
--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -263,7 +263,7 @@ class FieldSet:
         -----
         See https://ugrid-conventions.github.io/ugrid-conventions/ for more information on the UGRID conventions.
         """
-        model = UnstructuredModelData.from_ugrid_conventions(ds, mesh, vector_fields)
+        model = UnstructuredModelData.from_ugrid_conventions(ds, mesh=mesh, vector_fields=vector_fields)
         return cls([model])
 
     @classmethod
@@ -308,7 +308,7 @@ class FieldSet:
         See https://sgrid.github.io/sgrid/ for more information on the SGRID conventions.
         """
         model = StructuredModelData.from_sgrid_conventions(
-            ds, mesh, vector_fields, skip_field_data_validation=skip_field_data_validation
+            ds, mesh=mesh, vector_fields=vector_fields, skip_field_data_validation=skip_field_data_validation
         )
         return cls([model])
 

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -203,6 +203,7 @@ class StructuredModelData(ModelData):
     def from_sgrid_conventions(
         cls,
         ds: xr.Dataset,
+        *,
         mesh: ptyping.TMesh | None,
         vector_fields: ptyping.VectorFields | NotSetType,
         skip_field_data_validation: bool = False,
@@ -358,7 +359,7 @@ class UnstructuredModelData(ModelData):
 
     @classmethod
     def from_ugrid_conventions(
-        cls, ds: ux.UxDataset, mesh: ptyping.TMesh, vector_fields: ptyping.VectorFields | NotSetType
+        cls, ds: ux.UxDataset, *, mesh: ptyping.TMesh, vector_fields: ptyping.VectorFields | NotSetType
     ):
         ds_dims = list(ds.dims)
         if not all(dim in ds_dims for dim in ["time", "zf", "zc"]):

--- a/src/parcels/_core/particleset.py
+++ b/src/parcels/_core/particleset.py
@@ -60,6 +60,7 @@ class ParticleSet:
         self,
         fieldset,
         pclass=Particle,
+        *,
         t=None,
         z=None,
         y=None,


### PR DESCRIPTION
### Description

I was looking through the tutorial to see how we're using our functions, and to decide on which API should be keyword only. These are my thoughts

- `parcels.FieldSet.from_sgrid_conventions`
  - make `mesh`, `vector_fields`, `skip_field_data_validation` keyword only
- `parcels.FieldSet.from_ugrid_conventions`
  - make `mesh`, `vector_fields` keyword only
- `parcels.ParticleSet.__init__`
  - make particle initial values keyword only
- `ParticleFile.__init__`
  - leave as is (minimal chance of confusion)
- the rest - keep as is

This is a bit subjective. Happy to discuss if you have other thoughts @erikvansebille 


### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2716
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None used