### PR TITLE
Move uxarray to typechecking block

### DIFF
--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -7,7 +7,6 @@ from typing import IO, TYPE_CHECKING
 
 import cf_xarray  # noqa: F401
 import numpy as np
-import uxarray as ux
 import xarray as xr
 
 import parcels._typing as ptyping
@@ -29,6 +28,8 @@ from parcels.interpolators import (
 )
 
 if TYPE_CHECKING:
+    import uxarray as ux
+
     from parcels._core.basegrid import BaseGrid
     from parcels._typing import TimeLike
 __all__ = ["FieldSet"]

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Hashable, Sequence
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 import cf_xarray  # noqa: F401
-import uxarray as ux
 import xarray as xr
 import zarr
 from dask import is_dask_collection
@@ -36,6 +35,9 @@ from parcels.interpolators import (
     XLinear_Velocity,
 )
 from parcels.interpolators._base import ScalarInterpolator, VectorInterpolator
+
+if TYPE_CHECKING:
+    import uxarray as ux
 
 
 class ModelData(ABC):
@@ -320,6 +322,8 @@ CONSTANT_FIELD_MODELS = {
 
 class UnstructuredModelData(ModelData):
     def __init__(self, data: ux.UxDataset, grid: UxGrid, vector_field_components: ptyping.VectorFields):
+        import uxarray as ux
+
         if not isinstance(data, ux.UxDataset):
             raise ValueError(f"Expected `data` to be an uxarray.UxDataset . Got {type(data)}")
 

--- a/src/parcels/_core/uxgrid.py
+++ b/src/parcels/_core/uxgrid.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
-import uxarray as ux
 from dask import is_dask_collection
 
 from parcels._core.basegrid import BaseGrid
 from parcels._core.index_search import GRID_SEARCH_ERROR, _search_1d_array, uxgrid_point_in_cell
 from parcels._core.mesh import SphericalMesh, get_mesh
+
+if TYPE_CHECKING:
+    import uxarray as ux
 
 _UXGRID_AXES = Literal["Z", "FACE"]
 
@@ -36,6 +38,8 @@ class UxGrid(BaseGrid):
         mesh : str
             The type of mesh used for the grid. Either "flat" or "spherical".
         """
+        import uxarray as ux
+
         if grid.n_max_face_nodes > 3:
             raise ValueError("Provided ux.grid.Grid must contain only triangular cells (n_max_face_nodes=3)")
         self.uxgrid = grid


### PR DESCRIPTION
### Description

Save on import time (3.2s --> 1.6s ) by moving uxarray calls into typechecking blocks and to imports within parts of the code that use it.

There is no need to pay this import time at startup of Parcels, especially since people may not be running with unstructured grids anyway.

---

testing instructions:
```
pixi shell
python -X importtime -c 'import parcels' 2> tuna.log && tuna tuna.log
```

#### Before
<img width="1586" height="829" alt="image" src="https://github.com/user-attachments/assets/736aedc1-0bc8-46fc-8efd-a277723a0ce4" />


#### After

<img width="1503" height="827" alt="image" src="https://github.com/user-attachments/assets/1e4cec6f-a138-40f0-96d8-60bd03ca8f0d" />


### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2546
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None used