### PR TITLE
MAINT: Remove `--install-types` from typing Pixi command

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -163,7 +163,7 @@ pandas-stubs = "*"
 pyarrow-stubs = "*"
 
 [feature.typing.tasks]
-typing = { cmd = "mypy src/parcels --install-types", description = "Run static type checking with mypy." }
+typing = { cmd = "mypy src/parcels", description = "Run static type checking with mypy." }
 
 
 [environments]


### PR DESCRIPTION
### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes None
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None used