### PR TITLE
Add kernel linting via `@parcels.validate_kernel`

### DIFF
--- a/docs/user_guide/examples/tutorial_Argofloats.ipynb
+++ b/docs/user_guide/examples/tutorial_Argofloats.ipynb
@@ -13,8 +13,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tutorial shows how simple it is to construct a Kernel in Parcels that mimics the [vertical movement of Argo floats](https://www.aoml.noaa.gov/phod/argo/images/argo_float_mission.jpg).\n",
+    "This tutorial shows how simple it is to construct a Kernel in Parcels that mimics the [vertical movement of Argo floats](https://www.aoml.noaa.gov/phod/argo/images/argo_float_mission.jpg)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
     "\n",
+    "import numpy as np\n",
+    "\n",
+    "import parcels\n",
+    "import parcels.tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "We first define the Kernel for the vertical movement cycle of the Argo float."
    ]
   },
@@ -24,8 +43,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "\n",
     "# Define the new Kernel that mimics Argo vertical movement\n",
     "mindepth = 1.0  # minimum depth in m\n",
     "driftdepth = 1000  # maximum drift depth in m\n",
@@ -35,6 +52,7 @@
     "drifttime = 9 * 86400  # time of deep drift in seconds\n",
     "\n",
     "\n",
+    "@parcels.validate_kernel\n",
     "def ArgoVerticalMovement(particles, fieldset):\n",
     "    # Split particles based on their current cycle_phase\n",
     "    ptcls0 = particles[particles.cycle_phase == 0]\n",
@@ -97,11 +115,6 @@
    },
    "outputs": [],
    "source": [
-    "from datetime import timedelta\n",
-    "\n",
-    "import parcels\n",
-    "import parcels.tutorial\n",
-    "\n",
     "# Load the CopernicusMarine data in the Agulhas region from the example_datasets\n",
     "ds_fields = parcels.tutorial.open_dataset(\n",
     "    \"CopernicusMarine_data_for_Argo_tutorial/data\"\n",

--- a/docs/user_guide/examples/tutorial_gsw_density.ipynb
+++ b/docs/user_guide/examples/tutorial_gsw_density.ipynb
@@ -104,6 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "@parcels.validate_kernel\n",
     "def ParcelsGSW(particles, fieldset):\n",
     "    particles.temp = fieldset.thetao[particles]\n",
     "    particles.salt = fieldset.so[particles]\n",

--- a/docs/user_guide/getting_started/explanation_concepts.md
+++ b/docs/user_guide/getting_started/explanation_concepts.md
@@ -124,7 +124,7 @@ def AdvectionEE(particles, fieldset):
     particles.dy += v1 * particles.dt
 ```
 
-Note that the (optional) `@parcels.validate_kernel` decorator can be used to ensure that the kernel function is correctly defined and can be safely executed by parcels.
+Note that the (optional) `@parcels.validate_kernel` decorator can be used to ensure that the kernel function is correctly defined and follows recommendations.
 
 Basic kernels are included in Parcels to compute advection and diffusion. The standard advection kernel is {py:obj}`parcels.kernels.AdvectionRK2`, a [second-order Runge-Kutta integrator](https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods#The_Runge%E2%80%93Kutta_method) of the advection function.
 

--- a/docs/user_guide/getting_started/explanation_concepts.md
+++ b/docs/user_guide/getting_started/explanation_concepts.md
@@ -116,12 +116,15 @@ where $\mathbf{v}(\mathbf{x},t) = (u(\mathbf{x},t), v(\mathbf{x},t))$ describes 
 In Parcels, we can write a kernel function which integrates this equation at each timestep `particles.dt`. To do so, we need the ocean velocity field `fieldset.UV` at the `particles` location, and compute the change in position, `particles.dx` and `particles.dy`.
 
 ```python
+@parcels.validate_kernel
 def AdvectionEE(particles, fieldset):
     """Advection of particles using Explicit Euler (aka Euler Forward) integration."""
     (u1, v1) = fieldset.UV[particles]
     particles.dx += u1 * particles.dt
     particles.dy += v1 * particles.dt
 ```
+
+Note that the (optional) `@parcels.validate_kernel` decorator can be used to ensure that the kernel function is correctly defined and can be safely executed by parcels.
 
 Basic kernels are included in Parcels to compute advection and diffusion. The standard advection kernel is {py:obj}`parcels.kernels.AdvectionRK2`, a [second-order Runge-Kutta integrator](https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods#The_Runge%E2%80%93Kutta_method) of the advection function.
 

--- a/docs/user_guide/v4-migration.md
+++ b/docs/user_guide/v4-migration.md
@@ -88,6 +88,14 @@ How to migrate
 <div class="migration-chat">
 
 <div class="migration-bubble migration-change">
+The Kernel API has had some major changes (see also below)
+</div>
+<div class="migration-bubble migration-how">
+Add the <code>@parcels.validate_kernel</code> decorator above your Kernel function definition to check for errors and warnings.
+</div>
+<hr class="migration-divider" />
+
+<div class="migration-bubble migration-change">
 The Kernel loop is 'vectorized': the input of a Kernel is a collection of particles
 </div>
 <div class="migration-bubble migration-how">

--- a/src/parcels/__init__.py
+++ b/src/parcels/__init__.py
@@ -41,6 +41,7 @@ from parcels._core.warnings import (
     ParticleSetWarning,
     FieldEvalWarning,
 )
+from parcels._core.utils.kernel_linting import validate_kernel, KernelValidationError
 from parcels._logger import logger
 from . import convert
 from . import kernels
@@ -81,6 +82,9 @@ __all__ = [  # noqa: RUF022
     "convert",
     # kernels
     "kernels",
+    # Kernel validation
+    "validate_kernel",
+    "KernelValidationError",
 ]
 
 _stdlib_warnings.warn(

--- a/src/parcels/_core/kernel.py
+++ b/src/parcels/_core/kernel.py
@@ -16,11 +16,10 @@ from parcels._core.statuscodes import (
     _raise_grid_searching_error,
     _raise_outside_time_interval_error,
 )
+from parcels._core.utils.kernel_linting import validate_kernel
 from parcels._core.warnings import FieldEvalWarning, KernelWarning
-from parcels._python import assert_same_function_signature
 from parcels.kernels import (
     AdvectionAnalytical,
-    AdvectionRK4,
     AdvectionRK45,
 )
 
@@ -67,7 +66,7 @@ class Kernel:
         for f in kernels:
             if not isinstance(f, types.FunctionType):
                 raise TypeError(f"Argument `kernels` should be a function or list of functions. Got {type(f)}")
-            assert_same_function_signature(f, ref=AdvectionRK4, context="Kernel")
+            validate_kernel(f)
 
         if len(kernels) == 0:
             raise ValueError("List of `kernels` should have at least one function.")

--- a/src/parcels/_core/particleset.py
+++ b/src/parcels/_core/particleset.py
@@ -396,6 +396,7 @@ class ParticleSet:
 
         if isinstance(kernels, types.FunctionType):
             kernels = [kernels]
+
         self._kernel = Kernel(kernels, self)
 
         if output_file is not None:

--- a/src/parcels/_core/utils/kernel_linting.py
+++ b/src/parcels/_core/utils/kernel_linting.py
@@ -45,6 +45,8 @@ class _Violation:
 
 def _format_violations(func_name: str, violations: list[_Violation], label: str) -> str:
     """Format a list of violations into a readable string."""
+    if len(violations) == 0:
+        return ""
     header: str = f"Kernel `{func_name}` has {len(violations)} {label}(s):\n"
     lines: list[str] = []
     for v in violations:

--- a/src/parcels/_core/utils/kernel_linting.py
+++ b/src/parcels/_core/utils/kernel_linting.py
@@ -5,7 +5,7 @@ import inspect
 import textwrap
 import types
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TypeVar
 
@@ -30,7 +30,7 @@ _DEPRECATED_DELTA_NAMES: dict[str, str] = {
 
 _PARTICLE_NAMES: tuple[str, ...] = ("particle", "particles")
 
-_F = TypeVar("_F", bound=Callable[..., object])
+_F = TypeVar("_F", bound=types.FunctionType)
 
 
 class KernelValidationError(Exception):
@@ -195,7 +195,7 @@ class _KernelValidator(ast.NodeVisitor):
         self.generic_visit(node)
 
 
-def _validate_kernel_ast(func: Callable[..., object]) -> _ValidationResult:
+def _validate_kernel_ast(func: types.FunctionType) -> _ValidationResult:
     """Parse the AST of a kernel function and return a _ValidationResult."""
     source: str = textwrap.dedent(inspect.getsource(func))
     tree: ast.Module = ast.parse(source)

--- a/src/parcels/_core/utils/kernel_linting.py
+++ b/src/parcels/_core/utils/kernel_linting.py
@@ -11,7 +11,7 @@ from typing import TypeVar
 
 from parcels._core.warnings import KernelWarning
 
-_V4_MIGRATION_GUIDE: str = "https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html"
+_V4_MIGRATION_GUIDE: str = "https://docs.parcels-code.org/en/latest/user_guide/v4-migration.html"
 
 _DEPRECATED_COORD_ATTRS: dict[str, str] = {
     "lon": "x",

--- a/src/parcels/_core/utils/kernel_linting.py
+++ b/src/parcels/_core/utils/kernel_linting.py
@@ -17,6 +17,9 @@ _DEPRECATED_COORD_ATTRS: dict[str, str] = {
     "lon": "x",
     "lat": "y",
     "depth": "z",
+    "xi": "ei",
+    "yi": "ei",
+    "zi": "ei",
 }
 
 _DEPRECATED_DELTA_NAMES: dict[str, str] = {
@@ -24,8 +27,6 @@ _DEPRECATED_DELTA_NAMES: dict[str, str] = {
     "particle_dlat": "particles.dy",
     "particle_ddepth": "particles.dz",
 }
-
-_INDEX_ATTRS: set[str] = {"xi", "yi", "zi"}
 
 _PARTICLE_NAMES: tuple[str, ...] = ("particle", "particles")
 
@@ -130,11 +131,11 @@ class _KernelValidator(ast.NodeVisitor):
                 )
 
             # Index attribute sampling (warning)
-            if attr in _INDEX_ATTRS:
+            if attr == "ei":
                 self.result.warnings.append(
                     _Violation(
                         message=(
-                            f"Be careful when sampling `{name}.{attr}`, as this is updated "
+                            f"Be careful when sampling `{name}.ei`, as this is updated "
                             f"in the kernel loop. Best to place the sampling statement "
                             f"before advection."
                         ),
@@ -219,7 +220,7 @@ def validate_kernel(func: _F) -> _F:
     --------
     - References to deprecated ``particle.lon``, ``.lat``, ``.depth`` (use ``.x``, ``.y``, ``.z``)
     - References to deprecated ``particle_dlon``, ``particle_dlat``, ``particle_ddepth``
-    - Sampling ``particle.xi``/``.yi``/``.zi`` (ordering concern)
+    - Sampling ``particle.ei`` (ordering concern)
     """
     result: _ValidationResult = _validate_kernel_ast(func)
     report: str = result.get_report(func)

--- a/src/parcels/_core/utils/kernel_linting.py
+++ b/src/parcels/_core/utils/kernel_linting.py
@@ -174,7 +174,7 @@ class _KernelValidator(ast.NodeVisitor):
                 and isinstance(target.value, ast.Name)
                 and target.value.id in _PARTICLE_NAMES
             ):
-                self.result.errors.append(
+                self.result.warnings.append(
                     _Violation(
                         message=(
                             f"Don't change the location of a particle directly in a Kernel. "
@@ -214,12 +214,12 @@ def validate_kernel(func: _F) -> _F:
     Errors (raises ``KernelValidationError``):
     - Kernel signature is not ``def ...(particles, fieldset)``
     - ``particle.delete()`` or ``particles.delete()`` calls
-    - Direct assignment to particle location attributes (x/y/z/lon/lat/depth)
 
     Warnings
     --------
     - References to deprecated ``particle.lon``, ``.lat``, ``.depth`` (use ``.x``, ``.y``, ``.z``)
     - References to deprecated ``particle_dlon``, ``particle_dlat``, ``particle_ddepth``
+    - Direct assignment to particle location attributes (x/y/z/lon/lat/depth)
     - Sampling ``particle.ei`` (ordering concern)
     """
     result: _ValidationResult = _validate_kernel_ast(func)

--- a/src/parcels/_core/utils/kernel_linting.py
+++ b/src/parcels/_core/utils/kernel_linting.py
@@ -11,7 +11,7 @@ from typing import TypeVar
 
 from parcels._core.warnings import KernelWarning
 
-_MIGRATION_GUIDE: str = "https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html"
+_V4_MIGRATION_GUIDE: str = "https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html"
 
 _DEPRECATED_COORD_ATTRS: dict[str, str] = {
     "lon": "x",
@@ -30,7 +30,7 @@ _DEPRECATED_DELTA_NAMES: dict[str, str] = {
 
 _PARTICLE_NAMES: tuple[str, ...] = ("particle", "particles")
 
-_F = TypeVar("_F", bound=types.FunctionType)
+_F = TypeVar("_F", bound=Callable[..., object])
 
 
 class KernelValidationError(Exception):
@@ -84,7 +84,7 @@ class _KernelValidator(ast.NodeVisitor):
                     message=(
                         f"Kernel signature must be `def {self.func_name}(particles, fieldset)`, "
                         f"but got `def {self.func_name}({', '.join(param_names)})`. "
-                        f"See {_MIGRATION_GUIDE} for more info."
+                        f"See {_V4_MIGRATION_GUIDE} for more info."
                     ),
                 )
             )
@@ -103,7 +103,7 @@ class _KernelValidator(ast.NodeVisitor):
                     message=(
                         f"`{callee.value.id}.delete()` is no longer valid syntax in Parcels kernels. "
                         f"Use `particle.state = StatusCode.Delete` instead. "
-                        f"See {_MIGRATION_GUIDE} for more info."
+                        f"See {_V4_MIGRATION_GUIDE} for more info."
                     ),
                     lineno=node.lineno,
                 )
@@ -124,7 +124,7 @@ class _KernelValidator(ast.NodeVisitor):
                         message=(
                             f"`{name}.{attr}` is deprecated. "
                             f"Use `particles.{replacement}` instead. "
-                            f"See {_MIGRATION_GUIDE} for more info."
+                            f"See {_V4_MIGRATION_GUIDE} for more info."
                         ),
                         lineno=node.lineno,
                     )
@@ -157,7 +157,7 @@ class _KernelValidator(ast.NodeVisitor):
                     message=(
                         f"`{node.id}` is no longer valid in Parcels v4. "
                         f"Use `{replacement}` instead. "
-                        f"See {_MIGRATION_GUIDE} for more info."
+                        f"See {_V4_MIGRATION_GUIDE} for more info."
                     ),
                     lineno=node.lineno,
                 )
@@ -180,7 +180,7 @@ class _KernelValidator(ast.NodeVisitor):
                             f"Don't change the location of a particle directly in a Kernel. "
                             f"Use `particles.dx`, `particles.dy`, `particles.dz` instead of "
                             f"assigning to `{target.value.id}.{target.attr}`. "
-                            f"See {_MIGRATION_GUIDE} for more info."
+                            f"See {_V4_MIGRATION_GUIDE} for more info."
                         ),
                         lineno=lineno,
                     )

--- a/src/parcels/_core/utils/kernel_linting.py
+++ b/src/parcels/_core/utils/kernel_linting.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+import types
+import warnings
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+from parcels._core.warnings import KernelWarning
+
+_MIGRATION_GUIDE: str = "https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html"
+
+_DEPRECATED_COORD_ATTRS: dict[str, str] = {
+    "lon": "x",
+    "lat": "y",
+    "depth": "z",
+}
+
+_DEPRECATED_DELTA_NAMES: dict[str, str] = {
+    "particle_dlon": "particles.dx",
+    "particle_dlat": "particles.dy",
+    "particle_ddepth": "particles.dz",
+}
+
+_INDEX_ATTRS: set[str] = {"xi", "yi", "zi"}
+
+_PARTICLE_NAMES: tuple[str, ...] = ("particle", "particles")
+
+_F = TypeVar("_F", bound=types.FunctionType)
+
+
+class KernelValidationError(Exception):
+    """Raised when a kernel function has errors that make it incompatible with Parcels v4."""
+
+
+@dataclass
+class _Violation:
+    message: str
+    lineno: int | None = None
+
+
+def _format_violations(func_name: str, violations: list[_Violation], label: str) -> str:
+    """Format a list of violations into a readable string."""
+    header: str = f"Kernel `{func_name}` has {len(violations)} {label}(s):\n"
+    lines: list[str] = []
+    for v in violations:
+        prefix: str = f"Line {v.lineno}: " if v.lineno is not None else ""
+        lines.append(f"  - {prefix}{v.message}")
+    return header + "\n".join(lines)
+
+
+@dataclass
+class _ValidationResult:
+    errors: list[_Violation] = field(default_factory=list)
+    warnings: list[_Violation] = field(default_factory=list)
+
+    def get_report(self, func: types.FunctionType):
+        return "".join(
+            [
+                _format_violations(func.__name__, self.errors, "validation error"),
+                "\n\n",
+                _format_violations(func.__name__, self.warnings, "warning"),
+            ]
+        ).strip()
+
+
+class _KernelValidator(ast.NodeVisitor):
+    """AST NodeVisitor that collects kernel validation errors and warnings."""
+
+    def __init__(self, func_name: str) -> None:
+        self.func_name: str = func_name
+        self.result: _ValidationResult = _ValidationResult()
+
+    def check_signature(self, node: ast.FunctionDef) -> None:
+        """Check that the kernel signature is (particles, fieldset). Error if not."""
+        param_names: list[str] = [a.arg for a in node.args.args]
+        if param_names != ["particles", "fieldset"]:
+            self.result.errors.append(
+                _Violation(
+                    message=(
+                        f"Kernel signature must be `def {self.func_name}(particles, fieldset)`, "
+                        f"but got `def {self.func_name}({', '.join(param_names)})`. "
+                        f"See {_MIGRATION_GUIDE} for more info."
+                    ),
+                )
+            )
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """Check for particle.delete() / particles.delete() calls. Error."""
+        callee = node.func
+        if (
+            isinstance(callee, ast.Attribute)
+            and callee.attr == "delete"
+            and isinstance(callee.value, ast.Name)
+            and callee.value.id in _PARTICLE_NAMES
+        ):
+            self.result.errors.append(
+                _Violation(
+                    message=(
+                        f"`{callee.value.id}.delete()` is no longer valid syntax in Parcels kernels. "
+                        f"Use `particle.state = StatusCode.Delete` instead. "
+                        f"See {_MIGRATION_GUIDE} for more info."
+                    ),
+                    lineno=node.lineno,
+                )
+            )
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        """Check for deprecated and problematic attribute accesses. Warnings."""
+        if isinstance(node.value, ast.Name) and node.value.id in _PARTICLE_NAMES:
+            name: str = node.value.id
+            attr: str = node.attr
+
+            # Deprecated coordinate attributes (warning)
+            if attr in _DEPRECATED_COORD_ATTRS:
+                replacement: str = _DEPRECATED_COORD_ATTRS[attr]
+                self.result.warnings.append(
+                    _Violation(
+                        message=(
+                            f"`{name}.{attr}` is deprecated. "
+                            f"Use `particles.{replacement}` instead. "
+                            f"See {_MIGRATION_GUIDE} for more info."
+                        ),
+                        lineno=node.lineno,
+                    )
+                )
+
+            # Index attribute sampling (warning)
+            if attr in _INDEX_ATTRS:
+                self.result.warnings.append(
+                    _Violation(
+                        message=(
+                            f"Be careful when sampling `{name}.{attr}`, as this is updated "
+                            f"in the kernel loop. Best to place the sampling statement "
+                            f"before advection."
+                        ),
+                        lineno=node.lineno,
+                    )
+                )
+
+            # Direct assignment to location attributes (error)
+            # Handled in visit_Assign / visit_AugAssign instead
+
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        """Check for deprecated v3 delta variable names like particle_dlon. Warning."""
+        if node.id in _DEPRECATED_DELTA_NAMES:
+            replacement: str = _DEPRECATED_DELTA_NAMES[node.id]
+            self.result.warnings.append(
+                _Violation(
+                    message=(
+                        f"`{node.id}` is no longer valid in Parcels v4. "
+                        f"Use `{replacement}` instead. "
+                        f"See {_MIGRATION_GUIDE} for more info."
+                    ),
+                    lineno=node.lineno,
+                )
+            )
+        self.generic_visit(node)
+
+    def _check_location_assignment(self, targets: Sequence[ast.expr], lineno: int) -> None:
+        """Check if any target is a direct assignment to a particle location attribute. Error."""
+        location_attrs: set[str] = {"lon", "lat", "depth", "x", "y", "z"}
+        for target in targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr in location_attrs
+                and isinstance(target.value, ast.Name)
+                and target.value.id in _PARTICLE_NAMES
+            ):
+                self.result.errors.append(
+                    _Violation(
+                        message=(
+                            f"Don't change the location of a particle directly in a Kernel. "
+                            f"Use `particles.dx`, `particles.dy`, `particles.dz` instead of "
+                            f"assigning to `{target.value.id}.{target.attr}`. "
+                            f"See {_MIGRATION_GUIDE} for more info."
+                        ),
+                        lineno=lineno,
+                    )
+                )
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self._check_location_assignment(node.targets, node.lineno)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self._check_location_assignment([node.target], node.lineno)
+        self.generic_visit(node)
+
+
+def _validate_kernel_ast(func: Callable[..., object]) -> _ValidationResult:
+    """Parse the AST of a kernel function and return a _ValidationResult."""
+    source: str = textwrap.dedent(inspect.getsource(func))
+    tree: ast.Module = ast.parse(source)
+    func_def: ast.stmt = tree.body[0]
+
+    validator = _KernelValidator(func.__name__)
+    validator.check_signature(func_def)  # type: ignore[arg-type]
+    validator.visit(func_def)
+
+    return validator.result
+
+
+def validate_kernel(func: _F) -> _F:
+    """Decorator that validates a Parcels v4 kernel function.
+
+    Errors (raises ``KernelValidationError``):
+    - Kernel signature is not ``def ...(particles, fieldset)``
+    - ``particle.delete()`` or ``particles.delete()`` calls
+    - Direct assignment to particle location attributes (x/y/z/lon/lat/depth)
+
+    Warnings
+    --------
+    - References to deprecated ``particle.lon``, ``.lat``, ``.depth`` (use ``.x``, ``.y``, ``.z``)
+    - References to deprecated ``particle_dlon``, ``particle_dlat``, ``particle_ddepth``
+    - Sampling ``particle.xi``/``.yi``/``.zi`` (ordering concern)
+    """
+    result: _ValidationResult = _validate_kernel_ast(func)
+    report: str = result.get_report(func)
+
+    if result.warnings:
+        warnings.warn(report, KernelWarning, stacklevel=2)
+
+    if result.errors:
+        raise KernelValidationError(report)
+
+    return func

--- a/src/parcels/_python.py
+++ b/src/parcels/_python.py
@@ -1,7 +1,6 @@
 # Generic Python helpers
 import enum
-import inspect
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import TypeVar
 
 K = TypeVar("K")
@@ -26,27 +25,6 @@ def repr_from_dunder_dict(obj: object) -> str:
     """Dataclass-like __repr__ implementation based on __dict__."""
     parts = [f"{k}={v!r}" for k, v in obj.__dict__.items()]
     return f"{obj.__class__.__qualname__}(" + ", ".join(parts) + ")"
-
-
-def assert_same_function_signature(f: Callable, *, ref: Callable, context: str) -> None:
-    """Ensures a function `f` has the same signature as the reference function `ref`."""
-    sig_ref = inspect.signature(ref)
-    sig = inspect.signature(f)
-
-    if len(sig_ref.parameters) != len(sig.parameters):
-        raise ValueError(
-            f"{context} function must have {len(sig_ref.parameters)} parameters, got {len(sig.parameters)}"
-        )
-
-    for param1, param2 in zip(sig_ref.parameters.values(), sig.parameters.values(), strict=False):
-        if param1.kind != param2.kind:
-            raise ValueError(
-                f"Parameter '{param2.name}' has incorrect parameter kind. Expected {param1.kind}, got {param2.kind}"
-            )
-        if param1.name != param2.name:
-            raise ValueError(
-                f"Parameter '{param2.name}' has incorrect name. Expected '{param1.name}', got '{param2.name}'"
-            )
 
 
 def invert_non_unique_mapping(d: Mapping[K, V]) -> Mapping[V, list[K]]:

--- a/tests/mark.py
+++ b/tests/mark.py
@@ -3,3 +3,5 @@ import pytest
 zarr_filterwarning_consolidated_metadata = pytest.mark.filterwarnings(
     "ignore:Consolidated metadata is currently not part in the Zarr format 3 specification"
 )
+
+ignore_kernel_warnings = pytest.mark.filterwarnings("ignore:Kernel.*has.*warning")

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -37,6 +37,7 @@ from parcels.kernels import (
     AdvectionRK4_3D,
     AdvectionRK45,
 )
+from tests.mark import ignore_kernel_warnings
 from tests.utils import DEFAULT_PARTICLES, assert_cftime_like_particlefile
 
 
@@ -84,6 +85,7 @@ def periodicBC(particles, fieldset):
     particles.x = np.fmod(particles.x, 2)
 
 
+@ignore_kernel_warnings
 def test_advection_zonal_periodic():
     ds = simple_UV_dataset(dims=(2, 2, 2, 2), mesh="flat")
     ds["U"].data[:] = 0.1

--- a/tests/test_diffusion.py
+++ b/tests/test_diffusion.py
@@ -93,7 +93,7 @@ def test_randomexponential(lambd):
 
     def vertical_randomexponential(particles, fieldset):  # pragma: no cover
         # Kernel for random exponential variable in z direction
-        particles.z = np.random.exponential(scale=1 / fieldset.lambd, size=len(particles))
+        particles.dz += np.random.exponential(scale=1 / fieldset.lambd, size=len(particles))
 
     pset.execute(vertical_randomexponential, runtime=np.timedelta64(1, "s"), dt=np.timedelta64(1, "s"))
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -9,7 +9,6 @@ from parcels import (
     Variable,
 )
 from parcels._core.kernel import Kernel
-from parcels._core.utils.kernel_linting import KernelValidationError
 from parcels._datasets.structured.generated import simple_UV_dataset
 from parcels.kernels import AdvectionRK4, AdvectionRK45
 from tests.common_kernels import DoNothing, MoveEast, MoveNorth
@@ -126,46 +125,6 @@ def test_rk45_kernel_warnings(fieldset):
     )
     with pytest.warns(KernelWarning):
         pset.execute(AdvectionRK45, runtime=1, dt=1)
-
-
-def test_kernel_signature(fieldset):
-    pset = ParticleSet(fieldset, x=[0.5], y=[0.5])
-
-    def good_kernel(particles, fieldset):
-        pass
-
-    def version_3_kernel(particle, fieldset, time):
-        pass
-
-    def version_3_kernel_without_time(particle, fieldset):
-        pass
-
-    def kernel_switched_args(fieldset, particle):
-        pass
-
-    def kernel_with_forced_kwarg(particles, *, fieldset=0):
-        pass
-
-    Kernel(kernels=[good_kernel], pset=pset)
-
-    with pytest.raises(KernelValidationError, match="Kernel function must have 2 parameters, got 3"):
-        Kernel(kernels=[version_3_kernel], pset=pset)
-
-    with pytest.raises(
-        KernelValidationError, match="Parameter 'particle' has incorrect name. Expected 'particles', got 'particle'"
-    ):
-        Kernel(kernels=[version_3_kernel_without_time], pset=pset)
-
-    with pytest.raises(
-        KernelValidationError, match="Parameter 'fieldset' has incorrect name. Expected 'particles', got 'fieldset'"
-    ):
-        Kernel(kernels=[kernel_switched_args], pset=pset)
-
-    with pytest.raises(
-        KernelValidationError,
-        match="Parameter 'fieldset' has incorrect parameter kind. Expected POSITIONAL_OR_KEYWORD, got KEYWORD_ONLY",
-    ):
-        Kernel(kernels=[kernel_with_forced_kwarg], pset=pset)
 
 
 @ignore_kernel_warnings

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -9,9 +9,11 @@ from parcels import (
     Variable,
 )
 from parcels._core.kernel import Kernel
+from parcels._core.utils.kernel_linting import KernelValidationError
 from parcels._datasets.structured.generated import simple_UV_dataset
 from parcels.kernels import AdvectionRK4, AdvectionRK45
 from tests.common_kernels import DoNothing, MoveEast, MoveNorth
+from tests.mark import ignore_kernel_warnings
 
 
 def test_unknown_var_in_kernel(fieldset):
@@ -24,6 +26,7 @@ def test_unknown_var_in_kernel(fieldset):
         pset.execute(ErrorKernel, runtime=np.timedelta64(2, "s"), dt=np.timedelta64(1, "s"))
 
 
+@ignore_kernel_warnings
 def test_context_in_kernel(fieldset):
     pset = ParticleSet(fieldset, x=[0.5], y=[0.5])
 
@@ -36,6 +39,7 @@ def test_context_in_kernel(fieldset):
     assert pset.x == -0.5
 
 
+@ignore_kernel_warnings
 def test_func_context_in_kernel(fieldset):
     pset = ParticleSet(fieldset, x=[0.5], y=[0.5])
 
@@ -144,26 +148,27 @@ def test_kernel_signature(fieldset):
 
     Kernel(kernels=[good_kernel], pset=pset)
 
-    with pytest.raises(ValueError, match="Kernel function must have 2 parameters, got 3"):
+    with pytest.raises(KernelValidationError, match="Kernel function must have 2 parameters, got 3"):
         Kernel(kernels=[version_3_kernel], pset=pset)
 
     with pytest.raises(
-        ValueError, match="Parameter 'particle' has incorrect name. Expected 'particles', got 'particle'"
+        KernelValidationError, match="Parameter 'particle' has incorrect name. Expected 'particles', got 'particle'"
     ):
         Kernel(kernels=[version_3_kernel_without_time], pset=pset)
 
     with pytest.raises(
-        ValueError, match="Parameter 'fieldset' has incorrect name. Expected 'particles', got 'fieldset'"
+        KernelValidationError, match="Parameter 'fieldset' has incorrect name. Expected 'particles', got 'fieldset'"
     ):
         Kernel(kernels=[kernel_switched_args], pset=pset)
 
     with pytest.raises(
-        ValueError,
+        KernelValidationError,
         match="Parameter 'fieldset' has incorrect parameter kind. Expected POSITIONAL_OR_KEYWORD, got KEYWORD_ONLY",
     ):
         Kernel(kernels=[kernel_with_forced_kwarg], pset=pset)
 
 
+@ignore_kernel_warnings
 @pytest.mark.parametrize("kernel_type", ["update_lon", "update_dlon"])
 def test_execution_order(kernel_type):
     ds = simple_UV_dataset(dims=(1, 1, 2, 2), mesh="flat")

--- a/tests/test_particlefile.py
+++ b/tests/test_particlefile.py
@@ -370,7 +370,7 @@ def test_correct_misaligned_outputdt_dt(fieldset, tmp_parquet):
     """Testing that outputdt does not need to be a multiple of dt."""
 
     def Update_lon(particles, fieldset):  # pragma: no cover
-        particles.x += particles.dt
+        particles.dx = particles.dt
 
     particle = get_default_particle(np.float64)
     pset = ParticleSet(fieldset, pclass=particle, x=[0], y=[0])

--- a/tests/test_particleset_execute.py
+++ b/tests/test_particleset_execute.py
@@ -331,7 +331,7 @@ def test_dont_run_particles_outside_starttime(fieldset):
     endtime = fieldset.time_interval.left + np.timedelta64(8, "s")
 
     def AddLon(particles, fieldset):  # pragma: no cover
-        particles.x += 1
+        particles.dx += 1
 
     pset = ParticleSet(fieldset, x=np.zeros(len(start_times)), y=np.zeros(len(start_times)), t=start_times)
     pset.execute(AddLon, dt=np.timedelta64(1, "s"), endtime=endtime)
@@ -459,7 +459,7 @@ def test_execution_runtime(fieldset, starttime_flt, runtime_flt, dt, npart):
 
 def test_changing_dt_in_kernel(fieldset):
     def KernelCounter(particles, fieldset):  # pragma: no cover
-        particles.x += 1
+        particles.dx = 1
 
     pset = ParticleSet(fieldset, x=np.zeros(1), y=np.zeros(1))
     pset.execute(KernelCounter, dt=np.timedelta64(2, "s"), runtime=np.timedelta64(5, "s"))

--- a/tests/utils/test_kernel_linting.py
+++ b/tests/utils/test_kernel_linting.py
@@ -1,0 +1,254 @@
+import pytest
+
+from parcels._core.utils.kernel import KernelValidationError, validate_kernel
+from parcels._core.warnings import KernelWarning
+
+
+class TestValidKernel:
+    def test_valid_kernel_passes(self):
+        @validate_kernel
+        def my_kernel(particles, fieldset):
+            particles.dx += 1
+
+        assert callable(my_kernel)
+
+    def test_returns_original_function(self):
+        def my_kernel(particles, fieldset):
+            pass
+
+        result = validate_kernel(my_kernel)
+        assert result is my_kernel
+
+
+# === ERRORS (raise KernelValidationError) ===
+
+
+class TestSignatureErrors:
+    def test_singular_particle_rejected(self):
+        with pytest.raises(KernelValidationError, match="signature"):
+
+            @validate_kernel
+            def my_kernel(particle, fieldset):
+                pass
+
+    def test_extra_time_argument_rejected(self):
+        with pytest.raises(KernelValidationError, match="signature"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset, time):
+                pass
+
+    def test_wrong_param_names_rejected(self):
+        with pytest.raises(KernelValidationError, match="signature"):
+
+            @validate_kernel
+            def my_kernel(p, fs):
+                pass
+
+    def test_swapped_params_rejected(self):
+        with pytest.raises(KernelValidationError, match="signature"):
+
+            @validate_kernel
+            def my_kernel(fieldset, particles):
+                pass
+
+
+class TestDeleteErrors:
+    def test_particles_delete_rejected(self):
+        with pytest.raises(KernelValidationError, match=r"delete.*no longer valid"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particles.delete()
+
+    def test_particle_delete_in_body_rejected(self):
+        with pytest.raises(KernelValidationError, match=r"particle\.delete.*no longer valid"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particle = particles[0]
+                particle.delete()
+
+
+class TestDirectLocationAssignmentErrors:
+    def test_assign_to_x(self):
+        with pytest.raises(KernelValidationError, match="Don't change the location"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particles.x = 1.0
+
+    def test_assign_to_y(self):
+        with pytest.raises(KernelValidationError, match="Don't change the location"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particles.y = 1.0
+
+    def test_assign_to_z(self):
+        with pytest.raises(KernelValidationError, match="Don't change the location"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particles.z = 1.0
+
+    def test_assign_to_lon(self):
+        with pytest.raises(KernelValidationError, match="Don't change the location"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particles.lon = 1.0
+
+    def test_assign_to_lat(self):
+        with pytest.raises(KernelValidationError, match="Don't change the location"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particles.lat = 1.0
+
+    def test_assign_to_depth(self):
+        with pytest.raises(KernelValidationError, match="Don't change the location"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particles.depth = 1.0
+
+    def test_augassign_to_x(self):
+        with pytest.raises(KernelValidationError, match="Don't change the location"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particles.x += 1.0
+
+    def test_augassign_to_y(self):
+        with pytest.raises(KernelValidationError, match="Don't change the location"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particles.y += 1.0
+
+    def test_augassign_to_z(self):
+        with pytest.raises(KernelValidationError, match="Don't change the location"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particles.z += 1.0
+
+    def test_assign_to_dx_allowed(self):
+        @validate_kernel
+        def my_kernel(particles, fieldset):
+            particles.dx += 1.0
+
+        assert callable(my_kernel)
+
+    def test_assign_to_custom_attr_allowed(self):
+        @validate_kernel
+        def my_kernel(particles, fieldset):
+            particles.temperature = 20.0
+
+        assert callable(my_kernel)
+
+
+# === WARNINGS (emit KernelWarning) ===
+
+
+class TestDeprecatedCoordWarnings:
+    def test_lon_warns(self):
+        with pytest.warns(KernelWarning, match=r"particles\.lon.*particles\.x"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                val = particles.lon  # noqa: F841
+
+    def test_lat_warns(self):
+        with pytest.warns(KernelWarning, match=r"particles\.lat.*particles\.y"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                val = particles.lat  # noqa: F841
+
+    def test_depth_warns(self):
+        with pytest.warns(KernelWarning, match=r"particles\.depth.*particles\.z"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                val = particles.depth  # noqa: F841
+
+
+class TestDeprecatedDeltaWarnings:
+    def test_particle_dlon_warns(self):
+        with pytest.warns(KernelWarning, match=r"particle_dlon.*particles\.dx"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particle_dlon = 0.1  # noqa: F841
+
+    def test_particle_dlat_warns(self):
+        with pytest.warns(KernelWarning, match=r"particle_dlat.*particles\.dy"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particle_dlat = 0.1  # noqa: F841
+
+    def test_particle_ddepth_warns(self):
+        with pytest.warns(KernelWarning, match=r"particle_ddepth.*particles\.dz"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                particle_ddepth = 0.1  # noqa: F841
+
+
+class TestIndexSamplingWarnings:
+    def test_xi_warns(self):
+        with pytest.warns(KernelWarning, match=r"particles\.xi.*before advection"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                val = particles.xi  # noqa: F841
+
+    def test_yi_warns(self):
+        with pytest.warns(KernelWarning, match=r"particles\.yi.*before advection"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                val = particles.yi  # noqa: F841
+
+    def test_zi_warns(self):
+        with pytest.warns(KernelWarning, match=r"particles\.zi.*before advection"):
+
+            @validate_kernel
+            def my_kernel(particles, fieldset):
+                val = particles.zi  # noqa: F841
+
+
+# === MIXED: errors + warnings together ===
+
+
+class TestMixedViolations:
+    def test_warnings_emitted_before_error_raised(self):
+        with pytest.warns(KernelWarning, match="lon"):
+            with pytest.raises(KernelValidationError) as exc_info:
+
+                @validate_kernel
+                def my_kernel(particle, fieldset, time):
+                    x = particle.lon  # noqa: F841
+                    particle.delete()
+
+        msg = str(exc_info.value)
+        assert "signature" in msg
+        assert "delete" in msg
+        assert "2 validation error(s)" in msg
+
+    def test_multiple_errors_collected(self):
+        with pytest.raises(KernelValidationError) as exc_info:
+
+            @validate_kernel
+            def my_kernel(particle, fieldset, time):
+                particle.delete()
+                particle.x = 5
+
+        msg = str(exc_info.value)
+        assert "signature" in msg
+        assert "delete" in msg
+        assert "Don't change the location" in msg
+        assert "3 validation error(s)" in msg

--- a/tests/utils/test_kernel_linting.py
+++ b/tests/utils/test_kernel_linting.py
@@ -70,86 +70,72 @@ class TestDeleteErrors:
                 particle.delete()
 
 
-class TestDirectLocationAssignmentErrors:
+# === WARNINGS (emit KernelWarning) ===
+
+
+class TestDirectLocationAssignmentWarnings:
     def test_assign_to_x(self):
-        with pytest.raises(KernelValidationError, match="Don't change the location"):
+        with pytest.warns(KernelWarning, match="Don't change the location"):
 
             @validate_kernel
             def my_kernel(particles, fieldset):
                 particles.x = 1.0
 
     def test_assign_to_y(self):
-        with pytest.raises(KernelValidationError, match="Don't change the location"):
+        with pytest.warns(KernelWarning, match="Don't change the location"):
 
             @validate_kernel
             def my_kernel(particles, fieldset):
                 particles.y = 1.0
 
     def test_assign_to_z(self):
-        with pytest.raises(KernelValidationError, match="Don't change the location"):
+        with pytest.warns(KernelWarning, match="Don't change the location"):
 
             @validate_kernel
             def my_kernel(particles, fieldset):
                 particles.z = 1.0
 
     def test_assign_to_lon(self):
-        with pytest.raises(KernelValidationError, match="Don't change the location"):
+        with pytest.warns(KernelWarning, match="Don't change the location"):
 
             @validate_kernel
             def my_kernel(particles, fieldset):
                 particles.lon = 1.0
 
     def test_assign_to_lat(self):
-        with pytest.raises(KernelValidationError, match="Don't change the location"):
+        with pytest.warns(KernelWarning, match="Don't change the location"):
 
             @validate_kernel
             def my_kernel(particles, fieldset):
                 particles.lat = 1.0
 
     def test_assign_to_depth(self):
-        with pytest.raises(KernelValidationError, match="Don't change the location"):
+        with pytest.warns(KernelWarning, match="Don't change the location"):
 
             @validate_kernel
             def my_kernel(particles, fieldset):
                 particles.depth = 1.0
 
     def test_augassign_to_x(self):
-        with pytest.raises(KernelValidationError, match="Don't change the location"):
+        with pytest.warns(KernelWarning, match="Don't change the location"):
 
             @validate_kernel
             def my_kernel(particles, fieldset):
                 particles.x += 1.0
 
     def test_augassign_to_y(self):
-        with pytest.raises(KernelValidationError, match="Don't change the location"):
+        with pytest.warns(KernelWarning, match="Don't change the location"):
 
             @validate_kernel
             def my_kernel(particles, fieldset):
                 particles.y += 1.0
 
     def test_augassign_to_z(self):
-        with pytest.raises(KernelValidationError, match="Don't change the location"):
+        with pytest.warns(KernelWarning, match="Don't change the location"):
 
             @validate_kernel
             def my_kernel(particles, fieldset):
                 particles.z += 1.0
-
-    def test_assign_to_dx_allowed(self):
-        @validate_kernel
-        def my_kernel(particles, fieldset):
-            particles.dx += 1.0
-
-        assert callable(my_kernel)
-
-    def test_assign_to_custom_attr_allowed(self):
-        @validate_kernel
-        def my_kernel(particles, fieldset):
-            particles.temperature = 20.0
-
-        assert callable(my_kernel)
-
-
-# === WARNINGS (emit KernelWarning) ===
 
 
 class TestDeprecatedCoordWarnings:
@@ -226,7 +212,7 @@ class TestMixedViolations:
         assert "2 validation error(s)" in msg
 
     def test_multiple_errors_collected(self):
-        with pytest.raises(KernelValidationError) as exc_info:
+        with pytest.raises(KernelValidationError) as exc_info, pytest.warns(KernelWarning):
 
             @validate_kernel
             def my_kernel(particle, fieldset, time):
@@ -237,4 +223,4 @@ class TestMixedViolations:
         assert "signature" in msg
         assert "delete" in msg
         assert "Don't change the location" in msg
-        assert "3 validation error(s)" in msg
+        assert "2 validation error(s)" in msg

--- a/tests/utils/test_kernel_linting.py
+++ b/tests/utils/test_kernel_linting.py
@@ -1,6 +1,6 @@
 import pytest
 
-from parcels._core.utils.kernel import KernelValidationError, validate_kernel
+from parcels._core.utils.kernel_linting import KernelValidationError, validate_kernel
 from parcels._core.warnings import KernelWarning
 
 
@@ -199,26 +199,12 @@ class TestDeprecatedDeltaWarnings:
 
 
 class TestIndexSamplingWarnings:
-    def test_xi_warns(self):
-        with pytest.warns(KernelWarning, match=r"particles\.xi.*before advection"):
+    def test_ei_warns(self):
+        with pytest.warns(KernelWarning, match=r"particles\.ei.*before advection"):
 
             @validate_kernel
             def my_kernel(particles, fieldset):
-                val = particles.xi  # noqa: F841
-
-    def test_yi_warns(self):
-        with pytest.warns(KernelWarning, match=r"particles\.yi.*before advection"):
-
-            @validate_kernel
-            def my_kernel(particles, fieldset):
-                val = particles.yi  # noqa: F841
-
-    def test_zi_warns(self):
-        with pytest.warns(KernelWarning, match=r"particles\.zi.*before advection"):
-
-            @validate_kernel
-            def my_kernel(particles, fieldset):
-                val = particles.zi  # noqa: F841
+                val = particles.ei  # noqa: F841
 
 
 # === MIXED: errors + warnings together ===


### PR DESCRIPTION
### Description

This PR adds linting for Parcels kernels to help with correctness and for migration to v4.

The linting is broken up into errors and warnings:
- Errors are guaranteed to be incorrect
  - i.e., using an incorrect function signature for your kernels, calling `particles.delete()`
- Warnings are either likely to be incorrect, or give inaccurate results
  - using `particle_dlon` - a user might intentionally define this variable in their v4 kernel. There's no way to distinguish between that usage and someone upgrading their v3 kernel.
  - sampling `ei`, they should be warned about where they're sampling it

This linting is exposed via a decorator for users, and the docstring for `validate_kernel` shows which rules and looked for. I looked through the migration guide etc. and thought these rules were good, let me know @erikvansebille if you think additional rules are needed.

```python
@parcels.validate_kernel
def my_kernel(particle, fieldset, time): ...
```

providing an opt-in endpoint for raising these errors and warnings before the execution phase of a simulation

Internally in the execute loop these kernels are validated again. Providing the decorator is more for providing a good user experience for upgrading kernels.

#### Example kernel upgrade

The following kernel is taken from PlasticParcels

```python
import parcels
import math

@parcels.validate_kernel
def StokesDrift(particle, fieldset, time):
    # Sample the peak wave period
    T_p = fieldset.wave_Tp[time, particle.depth, particle.lat, particle.lon]

    # Compute the local bathymetry / water depth with a margin of error
    local_bathymetry = 0.99*fieldset.bathymetry[time, particle.depth, particle.lat, particle.lon]

    # Only compute displacements if the peak wave period is large enough and the particle is in the water
    if T_p > 1E-14 and particle.depth < local_bathymetry:
        # Sample the U / V components of Stokes drift
        stokes_U = fieldset.Stokes_U[time, particle.depth, particle.lat, particle.lon]
        stokes_V = fieldset.Stokes_V[time, particle.depth, particle.lat, particle.lon]

        # Peak wave frequency
        omega_p = 2. * math.pi / T_p

        # Peak wave number
        k_p = (omega_p ** 2) / fieldset.G

        # Repeated inner term of Eq. (19) - note depth is negative in this formulation, but model depths are positive by convention
        kp_z_2 = 2. * k_p * particle.depth

        # Decay factor in Eq. (19) -- Where beta=1 for the Phillips spectrum
        decay = math.exp(-kp_z_2) - math.sqrt(math.pi * kp_z_2) * math.erfc(math.sqrt(kp_z_2))

        # Apply Eq. (19) and compute particle displacement
        particle_dlon += stokes_U * decay * particle.dt  # noqa
        particle_dlat += stokes_V * decay * particle.dt  # noqa
```

which gives

```
/Users/Hodgs004/coding/repos/parcels/t.py:1: UserWarning: This is an alpha version of Parcels v4. The API is not stable and may change without deprecation warnings.
  import parcels
/Users/Hodgs004/coding/repos/parcels/t.py:4: KernelWarning: Kernel `StokesDrift` has 1 validation error(s):
  - Kernel signature must be `def StokesDrift(particles, fieldset)`, but got `def StokesDrift(particle, fieldset, time)`. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.

Kernel `StokesDrift` has 16 warning(s):
  - Line 4: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 4: `particle.lat` is deprecated. Use `particles.y` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 4: `particle.lon` is deprecated. Use `particles.x` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 7: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 7: `particle.lat` is deprecated. Use `particles.y` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 7: `particle.lon` is deprecated. Use `particles.x` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 10: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 12: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 12: `particle.lat` is deprecated. Use `particles.y` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 12: `particle.lon` is deprecated. Use `particles.x` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 13: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 13: `particle.lat` is deprecated. Use `particles.y` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 13: `particle.lon` is deprecated. Use `particles.x` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 22: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 28: `particle_dlon` is no longer valid in Parcels v4. Use `particles.dx` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 29: `particle_dlat` is no longer valid in Parcels v4. Use `particles.dy` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  @parcels.validate_kernel
Traceback (most recent call last):
  File "/Users/Hodgs004/coding/repos/parcels/t.py", line 4, in <module>
    @parcels.validate_kernel
     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Hodgs004/coding/repos/parcels/src/parcels/_core/utils/kernel_linting.py", line 232, in validate_kernel
    raise KernelValidationError(report)
parcels._core.utils.kernel_linting.KernelValidationError: Kernel `StokesDrift` has 1 validation error(s):
  - Kernel signature must be `def StokesDrift(particles, fieldset)`, but got `def StokesDrift(particle, fieldset, time)`. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.

Kernel `StokesDrift` has 16 warning(s):
  - Line 4: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 4: `particle.lat` is deprecated. Use `particles.y` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 4: `particle.lon` is deprecated. Use `particles.x` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 7: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 7: `particle.lat` is deprecated. Use `particles.y` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 7: `particle.lon` is deprecated. Use `particles.x` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 10: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 12: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 12: `particle.lat` is deprecated. Use `particles.y` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 12: `particle.lon` is deprecated. Use `particles.x` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 13: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 13: `particle.lat` is deprecated. Use `particles.y` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 13: `particle.lon` is deprecated. Use `particles.x` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 22: `particle.depth` is deprecated. Use `particles.z` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 28: `particle_dlon` is no longer valid in Parcels v4. Use `particles.dx` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
  - Line 29: `particle_dlat` is no longer valid in Parcels v4. Use `particles.dy` instead. See https://docs.oceanparcels.org/en/latest/user_guide/v4-migration.html for more info.
```

Note that there is a doubling up - the "report" is printed once for the warnings and once for the errors. I think that this is fine, and better than splitting them up (as warnings are likely errors as well, its nice to deal with them at the same time).



### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2109
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.parcels-code.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt): For creating the AST parsers and for creating the test suite
