### PR TITLE
BUG: Add FieldSet.constant_model attribute

### DIFF
--- a/src/parcels/_core/fieldset.py
+++ b/src/parcels/_core/fieldset.py
@@ -13,10 +13,10 @@ import xarray as xr
 import parcels._typing as ptyping
 from parcels._core.field import Field, VectorField
 from parcels._core.model import (
-    CONSTANT_FIELD_MODELS,
     ModelData,
     StructuredModelData,
     UnstructuredModelData,
+    create_empty_constant_field_model,
 )
 from parcels._core.utils.string import _assert_str_and_python_varname
 from parcels._core.utils.time import get_datetime_type_calendar
@@ -71,6 +71,7 @@ class FieldSet:
         # assert_compatible_calendars(fields)
 
         self.models = list(models)
+        self.constant_model: StructuredModelData | None = None
         self._fields: dict[str, Field | VectorField] | None = None
         self.reconstruct_fields()
         self.context: dict[str, float] = {}
@@ -96,6 +97,8 @@ class FieldSet:
         fields = []
         for model in self.models:
             fields += model.construct_fields()
+        if self.constant_model is not None:
+            fields += self.constant_model.construct_fields()
         self._fields = {f.name: f for f in fields}
 
     def __getattr__(self, name):
@@ -113,6 +116,16 @@ class FieldSet:
         assert_compatible_fieldsets(self, other)
         combined = FieldSet(self.models + other.models)
         combined.context = {**self.context, **other.context}
+        # Carry over constant model
+        if self.constant_model is not None and other.constant_model is not None:
+            # Merge data variables from both constant models into one
+            combined.constant_model = self.constant_model
+            for name in other.constant_model.scalar_field_names:
+                combined.constant_model.data[name] = other.constant_model.data[name]
+        elif self.constant_model is not None or other.constant_model is not None:
+            combined.constant_model = self.constant_model or other.constant_model
+
+        combined.reconstruct_fields()
         return combined
 
     # def __repr__(self):
@@ -189,15 +202,13 @@ class FieldSet:
                correction for zonal velocity U near the poles.
             2. flat: No conversion, lat/lon are assumed to be in m.
         """
-        try:
-            model = CONSTANT_FIELD_MODELS[mesh]
-        except KeyError as e:
-            raise ValueError(f"mesh must be one of ['flat', 'spherical']. Got {mesh!r}.") from e
+        if mesh not in ("flat", "spherical"):
+            raise ValueError(f"mesh must be one of ['flat', 'spherical']. Got {mesh!r}.")
 
-        model.data[name] = (["time", "depth", "lat", "lon"], np.full((1, 1, 1, 1), value))
+        if self.constant_model is None:
+            self.constant_model = create_empty_constant_field_model(mesh)
 
-        if model not in self.models:
-            self.models.append(model)
+        self.constant_model.data[name] = (["time", "depth", "lat", "lon"], np.full((1, 1, 1, 1), value))
 
         self.reconstruct_fields()
         field = getattr(self, name)

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -289,8 +289,9 @@ def assert_vector_field_components_in_dataset(ds: xr.Dataset, vector_fields: pty
     return
 
 
-CONSTANT_FIELD_MODELS = {
-    mesh: StructuredModelData.from_sgrid_conventions(
+def create_empty_constant_field_model(mesh: ptyping.TMesh) -> StructuredModelData:
+    """Create a empty model for constant fields with the given mesh type."""
+    return StructuredModelData.from_sgrid_conventions(
         xr.Dataset(
             {},
             coords={
@@ -314,8 +315,6 @@ CONSTANT_FIELD_MODELS = {
         mesh=mesh,  # type:ignore
         vector_fields={},
     )
-    for mesh in ["flat", "spherical"]
-}
 
 
 class UnstructuredModelData(ModelData):

--- a/src/parcels/_core/model.py
+++ b/src/parcels/_core/model.py
@@ -312,7 +312,7 @@ def create_empty_constant_field_model(mesh: ptyping.TMesh) -> StructuredModelDat
                 ),
             ),
         ),
-        mesh=mesh,  # type:ignore
+        mesh=mesh,
         vector_fields={},
     )
 

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -493,7 +493,7 @@ def test_fieldset_describe_backends(tmp_path):
 | UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: SphericalMesh(radius=6366707.019493707)
-time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-12T12:00:00.000000000'))
 """
     fieldset.describe(io)
     actual = io.getvalue()
@@ -513,7 +513,7 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
 | UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: SphericalMesh(radius=6366707.019493707)
-time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-12T12:00:00.000000000'))
 """
     fieldset.describe(io)
     actual = io.getvalue()
@@ -535,7 +535,7 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
 | UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: SphericalMesh(radius=6366707.019493707)
-time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-12T12:00:00.000000000'))
 """
     fieldset.describe(io)
     actual = io.getvalue()

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -447,7 +447,6 @@ def test_fieldset_describe(fieldset_two_models: FieldSet):
     fieldset = fieldset_two_models
     io = StringIO()
     expected = """\
-| Name           | Type        | Grid number   | Interp method / value   | Backend   |
 | Name           | Type        | Grid number   | Interp method / value   | Parcels backend   |
 |:---------------|:------------|:--------------|:------------------------|:------------------|
 | my_list        | Context     | -             | [1, 2, 'hello']         | -                 |
@@ -460,7 +459,7 @@ def test_fieldset_describe(fieldset_two_models: FieldSet):
 | UV_wind        | VectorField | 1             | XLinear_Velocity(...)   | -                 |
 | constant_field | Field       | 2             | XConstantField(...)     | NumPy             |
 
-mesh: flat
+mesh: FlatMesh()
 time interval: (np.datetime64('2000-01-01T00:00:00.000000000'), np.datetime64('2001-01-01T00:00:00.000000000'))
 """
     fieldset.describe(io)

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -443,9 +443,6 @@ def test_fieldset_add_context_values():
     assert fset.context["c2"] == 2.0
 
 
-@pytest.mark.xfail(
-    reason="There's test pollution occuring between test_fieldKh_Brownian and this test due to how constant fields are handled. We should remove this global state."
-)
 def test_fieldset_describe(fieldset_two_models: FieldSet):
     fieldset = fieldset_two_models
     io = StringIO()

--- a/tests/test_fieldset.py
+++ b/tests/test_fieldset.py
@@ -234,7 +234,8 @@ def test_multi_model_time_interval():
 
     fieldset.add_constant_field("constant_field", 1.0, mesh="flat")
 
-    assert len(fieldset.models) == 4
+    assert len(fieldset.models) == 3
+    assert fieldset.constant_model is not None
     assert fieldset.time_interval.left == np.datetime64("2000-01-03")
     assert fieldset.time_interval.right == np.datetime64("2001-01-01")
 
@@ -253,7 +254,8 @@ def test_multi_model_nonoverlapping_time_interval():
 
     fieldset.add_constant_field("constant_field", 1.0, mesh="flat")
 
-    assert len(fieldset.models) == 4
+    assert len(fieldset.models) == 3
+    assert fieldset.constant_model is not None
     assert fieldset.time_interval is None
 
 
@@ -491,7 +493,7 @@ def test_fieldset_describe_backends(tmp_path):
 | UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: SphericalMesh(radius=6366707.019493707)
-time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-12T12:00:00.000000000'))
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
 """
     fieldset.describe(io)
     actual = io.getvalue()
@@ -511,7 +513,7 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
 | UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: SphericalMesh(radius=6366707.019493707)
-time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-12T12:00:00.000000000'))
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
 """
     fieldset.describe(io)
     actual = io.getvalue()
@@ -533,7 +535,7 @@ time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2
 | UVW    | VectorField |             0 | CGrid_Velocity(...)     | -                 |
 
 mesh: SphericalMesh(radius=6366707.019493707)
-time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-12T12:00:00.000000000'))
+time interval: (np.datetime64('2000-01-02T12:00:00.000000000'), np.datetime64('2000-01-27T12:00:00.000000000'))
 """
     fieldset.describe(io)
     actual = io.getvalue()


### PR DESCRIPTION
### Description

Fixed a bug that resulted in shared global state between fieldsets when working with constant fields.

The Models used for the constant fields now live on the FieldSets themselves.


### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2736
- [ ] Tests added - **to some extent. I want to add more tests in https://github.com/Parcels-code/Parcels/issues/2727 **
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.parcels-code.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt): Told the LLM the implementation I wanted
