### PR TITLE
MAINT: Avoid deprecated generic timedelta

### DIFF
--- a/src/parcels/_core/utils/time.py
+++ b/src/parcels/_core/utils/time.py
@@ -182,7 +182,7 @@ def maybe_convert_python_timedelta_to_numpy(dt: timedelta | np.timedelta64) -> n
                 dts.append(np.timedelta64(value, np_unit))
 
         if dts:
-            return sum(dts)
+            return np.sum(dts)
         else:
             return np.timedelta64(0, "s")
     except Exception as e:

--- a/src/parcels/_datasets/structured/strategies.py
+++ b/src/parcels/_datasets/structured/strategies.py
@@ -6,6 +6,10 @@ from hypothesis.extra.numpy import arrays as np_arrays
 import parcels._sgrid as sgrid
 import parcels._strategies as pst
 
+TCoords1D = np.ndarray[tuple[int], np.dtype[np.float64]]
+TCoords2D = np.ndarray[tuple[int, int], np.dtype[np.float64]]
+TCoords = TCoords1D | TCoords2D
+
 
 @st.composite
 def sgrid_dataset(draw, grid: sgrid.SGrid2DMetadata | None = None) -> xr.Dataset:
@@ -35,6 +39,8 @@ def sgrid_dataset(draw, grid: sgrid.SGrid2DMetadata | None = None) -> xr.Dataset
     has_curvilinear_grid = draw(st.booleans())
     coord_name1, coord_name2 = grid.node_coordinates
 
+    c1: TCoords  # pyright: ignore[reportInvalidTypeForm]
+    c2: TCoords  # pyright: ignore[reportInvalidTypeForm]
     if has_curvilinear_grid:
         c1, c2 = np.meshgrid(np.linspace(0, 100, N), np.linspace(0, 100, M), indexing="ij")
         coord1_dims = [node_dim1, node_dim2]


### PR DESCRIPTION
### Description

Per https://numpy.org/doc/2.5/release/2.5.0-notes.html 

> Using the generic unit in numpy.timedelta64 is deprecated since this can lead to unexpected behavior such as non-transitive comparison, see [gh-28287](https://github.com/numpy/numpy/issues/28287) for details. As an alternative, specify an explicit unit such as 's' (seconds) or 'D' (days) when constructing numpy.timedelta64. Due to this change, operations that implicitly rely on the generic unit are also deprecated. For example:
> ```
> arr = np.array([1, 2, 3], dtype="m8[s]")
> 
> # `1` is implicitly converted to generic timedelta64
> arr + 1
> ```

The implementation of Python's `sum` is `0 + element_1 + ...`, which now fails for these timedelta objects.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] contributes to #2849
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

None used