### PR TITLE
Fix label on upstream-dev-ci.yaml issue-from-pytest-log-action

### DIFF
--- a/.github/workflows/upstream-dev-ci.yaml
+++ b/.github/workflows/upstream-dev-ci.yaml
@@ -159,3 +159,4 @@ jobs:
         with:
           log-path: logs/${{ needs.upstream-dev.outputs.log-file }}
           assignees: VeckoTheGecko,erikvansebille
+          issue-label: automated


### PR DESCRIPTION
### Description

Previously the workflow defaulted to the label `CI`, which didn't exist. We already use `automated` - updating to that.