### PR TITLE
Add re-assert to nightly/pixi.toml

### DIFF
--- a/ci/nightly/pixi.toml
+++ b/ci/nightly/pixi.toml
@@ -32,6 +32,7 @@ pytest-html = "*"
 pytest-cov = "*"
 pytest-reportlog = "*"
 pytest-timeout = "*"
+re-assert = "*"
 
 [feature.test.tasks]
 tests-nightly = { cmd = "pytest --run-validation-tests", cwd = "../..", description = "Run nightly tests (normal tests and validation tests)" }


### PR DESCRIPTION
### Description

Forgot to do so as part of #2876, causing failures on the nightly workflow.