### PR TITLE
Account for spherical face bulging during hashgrid construction and point in cell checks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -521,9 +521,6 @@ nb_execution_mode = "cache"
 nb_execution_excludepatterns = ["jupyter_execute", ".jupyter_cache"]
 nb_execution_raise_on_error = True
 nb_execution_timeout = 75
-nb_execution_excludepatterns = [
-    "user_guide/examples/tutorial_nestedgrids.ipynb"
-]  # TODO: Remove once https://github.com/Parcels-code/Parcels/issues/2878 is fixed
 suppress_warnings = ["mystnb.unknown_mime_type"]
 nitpicky = True
 nitpick_ignore_regex = [

--- a/docs/user_guide/examples/tutorial_nestedgrids.ipynb
+++ b/docs/user_guide/examples/tutorial_nestedgrids.ipynb
@@ -334,7 +334,7 @@
     ")\n",
     "uxda = ux.UxDataArray(ds_tri[\"GridID\"], uxgrid=ux.Grid(ds_tri)).to_dataset()\n",
     "uxda = uxda.assign_coords({\"zf\": ds_tri.coords[\"zf\"]})\n",
-    "fieldset = parcels.FieldSet.from_ugrid_conventions(uxda, mesh=\"flat\")"
+    "fieldset = parcels.FieldSet.from_ugrid_conventions(uxda, mesh=\"spherical\")"
    ]
   },
   {

--- a/src/parcels/_core/index_search.py
+++ b/src/parcels/_core/index_search.py
@@ -335,20 +335,31 @@ def uxgrid_point_in_cell(grid, y: np.ndarray, x: np.ndarray, yi: np.ndarray, xi:
             axis=-1,
         )
 
-        # Get projection points onto element plane. Keep the leading
-        # dimension even for single-face queries so shapes remain (M,3).
-        r1 = face_vertices[:, 1, :] - face_vertices[:, 0, :]
-        r2 = face_vertices[:, 2, :] - face_vertices[:, 0, :]
-        nhat = np.cross(r1, r2)
-        norm = np.linalg.norm(nhat, axis=-1)
-        # Avoid division by zero for degenerate faces
-        norm = np.where(norm == 0.0, 1.0, norm)
-        nhat = nhat / norm[:, None]
-        # Calculate the component of the points in the direction of nhat
-        ptilde = points - face_vertices[:, 0, :]
-        pdotnhat = np.sum(ptilde * nhat, axis=-1)
-        # Reconstruct points with normal component removed.
-        points = ptilde - pdotnhat[:, None] * nhat + face_vertices[:, 0, :]
+        # Barycentric coordinates of each point solved directly: coords = w0,w1,w2
+        # such that w0*v0 + w1*v1 + w2*v2 = point, normalized to sum to 1.
+        # This is the gnomonic projection such that each point is projected
+        # onto the face a ray that goes through the center of the unit sphere.
+        face_matrix = np.stack(
+            (face_vertices[:, 0, :], face_vertices[:, 1, :], face_vertices[:, 2, :]),
+            axis=-1,
+        )  # (M, 3, 3), columns v0, v1, v2
+
+        # The trailing single axis on `points` tells np.linalg.solve to treat
+        # the leading M as a batch dimension (one 3x3 solve per point), not as
+        # the matrix size.
+        weights = np.linalg.solve(face_matrix, points[..., None])  # (M, 3, 1)
+        # drop the trailing axis
+        weights = weights[..., 0]  # (M, 3)
+        weight_sum = weights.sum(axis=-1, keepdims=True)
+
+        # A point is inside only if it's a non-negative combination of the 3
+        # vertices.
+        is_in_cell = np.where(np.all(weights >= -1e-9, axis=1) & (weight_sum[:, 0] > 0), 1, 0)
+
+        # weight_sum can be exactly 0 for a candidate face the point isn't in,
+        # is_in_cell already excludes these, this avoids a spurious divide-by-zero warning only.
+        safe_weight_sum = np.where(weight_sum == 0.0, 1.0, weight_sum)
+        coords = weights / safe_weight_sum
 
     else:
         nids = grid.uxgrid.face_node_connectivity[xi, :].values
@@ -361,13 +372,10 @@ def uxgrid_point_in_cell(grid, y: np.ndarray, x: np.ndarray, yi: np.ndarray, xi:
         )
         points = np.stack((x, y), axis=-1)
 
-    M = len(points)
+        coords = _barycentric_coordinates(face_vertices, points)
 
-    coords = _barycentric_coordinates(face_vertices, points)
-
-    is_in_cell = np.zeros(M, dtype=np.int32)
-    is_in_cell = np.where(np.all((coords >= -1e-6), axis=1), 1, 0)
-    is_in_cell &= np.isclose(np.sum(coords, axis=1), 1.0, rtol=1e-3, atol=1e-6)
+        is_in_cell = np.where(np.all((coords >= -1e-6), axis=1), 1, 0)
+        is_in_cell &= np.isclose(np.sum(coords, axis=1), 1.0, rtol=1e-3, atol=1e-6)
 
     return is_in_cell, coords
 

--- a/src/parcels/_core/index_search.py
+++ b/src/parcels/_core/index_search.py
@@ -335,16 +335,15 @@ def uxgrid_point_in_cell(grid, y: np.ndarray, x: np.ndarray, yi: np.ndarray, xi:
             axis=-1,
         )
 
-        # Barycentric coordinates of each point solved directly: coords = w0,w1,w2
+        # Construcuct a matrix of face positions to solve for the
+        # byarycentric coordinates of each point, and then convert to coords = w0,w1,w2
         # such that w0*v0 + w1*v1 + w2*v2 = point, normalized to sum to 1.
-        # This is the gnomonic projection such that each point is projected
-        # onto the face a ray that goes through the center of the unit sphere.
         face_matrix = np.stack(
             (face_vertices[:, 0, :], face_vertices[:, 1, :], face_vertices[:, 2, :]),
             axis=-1,
         )  # (M, 3, 3), columns v0, v1, v2
 
-        # The trailing single axis on `points` tells np.linalg.solve to treat
+        # The trailing single axis on points tells np.linalg.solve to treat
         # the leading M as a batch dimension (one 3x3 solve per point), not as
         # the matrix size.
         weights = np.linalg.solve(face_matrix, points[..., None])  # (M, 3, 1)

--- a/src/parcels/_core/index_search.py
+++ b/src/parcels/_core/index_search.py
@@ -94,11 +94,11 @@ def _search_time_index(field: Field, time: np.ndarray):
 def curvilinear_point_in_cell(grid, y: np.ndarray, x: np.ndarray, yi: np.ndarray, xi: np.ndarray):
     """Locate points within 2D curvilinear grid cells.
 
-    For spherical grids, the bilinear inverse runs in a tangent plane on a sphere
-    through each cell's centroid — robust across the antimeridian and the
-    polar cap. For flat grids it runs directly in (lon, lat). In both
-    cases the returned (xsi, eta) are bilinear weights in the space the inverse
-    was solved in; downstream interpolators must agree on that same space.
+    For spherical grids, the bilinear inverse runs in a plane tangent to the sphere at
+    each cell's centroid, which is robust across the antimeridian and the polar cap. For
+    flat grids it runs directly in (lon, lat). In both cases the returned (xsi, eta) are
+    bilinear weights in the space the inverse was solved in; downstream interpolators
+    must agree on that same space.
     """
     clon = np.asarray(
         [grid.lon[yi, xi], grid.lon[yi, xi + 1], grid.lon[yi + 1, xi + 1], grid.lon[yi + 1, xi]],
@@ -180,8 +180,9 @@ def _bilinear_inverse_tangent_plane(clon, clat, x, y):
 def _spherical_project_cell_and_query(clon, clat, x, y):
     """Project 4 cell corners and the query onto a plane defined by the cell.
 
-    The plane's basis (e_u, e_v) is built from the cell's edge-midpoint
-    difference vectors, then orthonormalized using Gramm-Schmidt
+    The plane touches the sphere at the cell's centre, and its basis (e_u, e_v) is
+    built from the cell's edge-midpoint difference vectors, then orthonormalized
+    using Gramm-Schmidt
 
     Inputs
     ------
@@ -195,10 +196,15 @@ def _spherical_project_cell_and_query(clon, clat, x, y):
 
     Notes
     -----
-    Orthogonal projection is 2-to-1 on the full sphere: a query and its
-    antipode map to the same (u, v). In practice this is harmless because the
-    downstream bilinear gate ``(xsi, eta) in [0, 1]`` only admits queries whose
-    projected magnitude is ≲ the cell's angular size.
+    The projection is gnomonic (central), which maps great circles to straight
+    lines. A cell's edges are great-circle arcs, so the projected cell is a
+    straight-sided quadrilateral and the bilinear inverse measures a point
+    against the cell's true boundary at any cell size.
+
+    A ray from the origin meets the plane once, so the projection is 2-to-1 on
+    the full sphere: a query and its antipode share a ray and land on the same
+    (u, v). Only the hemisphere facing the plane is kept, which makes the map
+    one-to-one; points behind it project to NaN and fail the bilinear gate.
     """
     cX, cY, cZ = _latlon_rad_to_xyz(np.deg2rad(clat), np.deg2rad(clon))  # (4, N) each
     qX, qY, qZ = _latlon_rad_to_xyz(np.deg2rad(np.asarray(y, dtype=float)), np.deg2rad(np.asarray(x, dtype=float)))
@@ -227,11 +233,23 @@ def _spherical_project_cell_and_query(clon, clat, x, y):
     v_norm = np.where(v_norm == 0.0, 1.0, v_norm)
     e_vx, e_vy, e_vz = vx / v_norm, vy / v_norm, vz / v_norm
 
-    # Orthogonal projection onto span(e_u, e_v): two dot products per point.
-    # Same pattern as uxgrid_point_in_cell (drop the component normal to the plane).
+    # Unit normal of the plane, which is tangent to the sphere at the cell's centre.
+    nx = cX.sum(axis=0)
+    ny = cY.sum(axis=0)
+    nz = cZ.sum(axis=0)
+    n_norm = np.sqrt(nx * nx + ny * ny + nz * nz)
+    n_norm = np.where(n_norm == 0.0, 1.0, n_norm)
+    e_nx, e_ny, e_nz = nx / n_norm, ny / n_norm, nz / n_norm
+
+    # Gnomonic projection: scale each direction until it meets the plane, then read off
+    # its two in-plane components.
     def _project(vx, vy, vz):
-        u = vx * e_ux + vy * e_uy + vz * e_uz
-        v = vx * e_vx + vy * e_vy + vz * e_vz
+        # A direction pointing away from the plane never meets it. Setting those to NaN
+        # keeps the division quiet and leaves them to fail the caller's bilinear gate.
+        along_normal = vx * e_nx + vy * e_ny + vz * e_nz
+        scale = 1.0 / np.where(along_normal > 0.0, along_normal, np.nan)
+        u = scale * (vx * e_ux + vy * e_uy + vz * e_uz)
+        v = scale * (vx * e_vx + vy * e_vy + vz * e_vz)
         return u, v
 
     px_u, px_v = _project(cX, cY, cZ)  # (4, N) each

--- a/src/parcels/_core/spatialhash.py
+++ b/src/parcels/_core/spatialhash.py
@@ -62,49 +62,35 @@ class SpatialHash:
                 lon = np.deg2rad(self._source_grid.lon)
                 lat = np.deg2rad(self._source_grid.lat)
                 x, y, z = _latlon_rad_to_xyz(lat, lon)
+
+                # The 4 nodes of each face, wound around it
+                nodes = np.stack((x, y, z), axis=-1)
+                verts = np.stack(
+                    (
+                        nodes[:-1, :-1],
+                        nodes[:-1, 1:],
+                        nodes[1:, 1:],
+                        nodes[1:, :-1],
+                    ),
+                    axis=-2,
+                )
+
+                # Compute the exact bounding box of each face. A face's edges are
+                # great-circle arcs, so its true x/y/z extent is often not spanned by
+                # its node coordinates alone.
+                self._xlow, self._xhigh, self._ylow, self._yhigh, self._zlow, self._zhigh = (
+                    _spherical_face_bounds(verts)
+                )
+
                 # Boundaries of the hash grid are the Cartesian bounding box of the
                 # transformed grid, so that regional domains retain full quantization
                 # resolution instead of spreading it over the whole unit cube
-                self._xmin = np.nanmin(x)
-                self._xmax = np.nanmax(x)
-                self._ymin = np.nanmin(y)
-                self._ymax = np.nanmax(y)
-                self._zmin = np.nanmin(z)
-                self._zmax = np.nanmax(z)
-                _xbound = np.stack(
-                    (
-                        x[:-1, :-1],
-                        x[:-1, 1:],
-                        x[1:, 1:],
-                        x[1:, :-1],
-                    ),
-                    axis=-1,
-                )
-                _ybound = np.stack(
-                    (
-                        y[:-1, :-1],
-                        y[:-1, 1:],
-                        y[1:, 1:],
-                        y[1:, :-1],
-                    ),
-                    axis=-1,
-                )
-                _zbound = np.stack(
-                    (
-                        z[:-1, :-1],
-                        z[:-1, 1:],
-                        z[1:, 1:],
-                        z[1:, :-1],
-                    ),
-                    axis=-1,
-                )
-                # Compute centroid locations of each cells
-                self._xlow = np.min(_xbound, axis=-1)
-                self._xhigh = np.max(_xbound, axis=-1)
-                self._ylow = np.min(_ybound, axis=-1)
-                self._yhigh = np.max(_ybound, axis=-1)
-                self._zlow = np.min(_zbound, axis=-1)
-                self._zhigh = np.max(_zbound, axis=-1)
+                self._xmin = np.nanmin(self._xlow)
+                self._xmax = np.nanmax(self._xhigh)
+                self._ymin = np.nanmin(self._ylow)
+                self._ymax = np.nanmax(self._yhigh)
+                self._zmin = np.nanmin(self._zlow)
+                self._zmax = np.nanmax(self._zhigh)
 
                 degenerate_mask = _find_degenerate_xgrid_faces(x, y, z)
                 degeneracy_count = np.sum(degenerate_mask)
@@ -171,7 +157,7 @@ class SpatialHash:
                 vx, vy, vz = _latlon_rad_to_xyz(np.deg2rad(lat), np.deg2rad(lon))
                 verts = np.stack([vx, vy, vz], axis=-1)  # (nfaces, 3 nodes, 3)
 
-                self._xlow, self._xhigh, self._ylow, self._yhigh, self._zlow, self._zhigh = _spherical_triangle_bounds(
+                self._xlow, self._xhigh, self._ylow, self._yhigh, self._zlow, self._zhigh = _spherical_face_bounds(
                     verts
                 )
 
@@ -663,8 +649,8 @@ _AXIS_POINTS = np.array(
 )
 
 
-def _spherical_triangle_bounds(verts):
-    """Exact per-face x/y/z bounding box for triangular faces on the unit sphere,
+def _spherical_face_bounds(verts):
+    """Exact per-face x/y/z bounding box for convex faces on the unit sphere,
     computed in closed form (no sampling).
 
     A face's edges are great-circle arcs, so the true min/max of x, y, or z
@@ -683,8 +669,8 @@ def _spherical_triangle_bounds(verts):
 
     Parameters
     ----------
-    verts : ndarray, shape (nfaces, 3, 3)
-        Unit-sphere xyz coordinates of each face's 3 nodes, in winding order.
+    verts : ndarray, shape (nfaces, nodes_per_face, 3)
+        Unit-sphere xyz coordinates of each face's nodes, in winding order.
         The last axis is (x, y, z).
 
     Returns
@@ -692,74 +678,80 @@ def _spherical_triangle_bounds(verts):
     xlow, xhigh, ylow, yhigh, zlow, zhigh : ndarray, shape (nfaces,)
     """
     # --- Step 1: Calculate the bounds from the nodes themselves ----
-    v0, v1, v2 = verts[:, 0, :], verts[:, 1, :], verts[:, 2, :]
-    nfaces = verts.shape[0]
+    nodes_per_face = verts.shape[-2]
 
-    xlow, ylow, zlow = np.min(verts, axis=1).T
-    xhigh, yhigh, zhigh = np.max(verts, axis=1).T
+    low = np.min(verts, axis=-2)  # (..., 3), so low[..., 0] holds every face's x bound
+    high = np.max(verts, axis=-2)
 
     # --- Step 2: Check which faces the global extrema fall into (using a gnomonic projection) ---
-    M = np.stack([v0, v1, v2], axis=-1)  # (nfaces, 3, 3), columns v0, v1, v2
-    rhs = np.broadcast_to(_AXIS_POINTS.T, (nfaces, 3, 6))
-    w = np.linalg.solve(M, rhs)  # (nfaces, 3, 6): weights per axis point
+    # A point is inside a triangle of nodes when it can be written as a combination of
+    # the three node vectors using no negative weights. Solving for those weights needs
+    # exactly three nodes, so a face with more nodes is split into a fan of triangles
+    # sharing its first node, and a point inside any one of those triangles is inside
+    # the face.
+    inside = np.zeros(verts.shape[:-2] + (len(_AXIS_POINTS),), dtype=bool)  # (..., 6)
+    for node in range(1, nodes_per_face - 1):
+        M = np.stack([verts[..., 0, :], verts[..., node, :], verts[..., node + 1, :]], axis=-1)
 
-    # An axis point is in a face if its weights are >=0 (1e-12 accounts for machine precision).
-    inside = np.all(w >= -1e-12, axis=1)  # (nfaces, 6)
+        # A triangle with no area encloses nothing. Rather
+        # than let np.linalg.solve raise on it, conver those faces' weights to NaN.
+        weights = np.full(M.shape[:-1] + (len(_AXIS_POINTS),), np.nan)
+        has_area = np.abs(np.linalg.det(M)) > 1e-14
+        if has_area.any():
+            weights[has_area] = np.linalg.solve(M[has_area], _AXIS_POINTS.T)
+
+        # An axis point is in the triangle if its weights are >=0 (1e-12 accounts for
+        # machine precision).
+        inside |= np.all(weights >= -1e-12, axis=-2)
 
     # For faces that contain a global extreme point, override the bound to use that point (which
-    # will be either 1 or -1 on the unit sphere).
-    xhigh = np.where(inside[:, 0], 1.0, xhigh)
-    xlow = np.where(inside[:, 1], -1.0, xlow)
-    yhigh = np.where(inside[:, 2], 1.0, yhigh)
-    ylow = np.where(inside[:, 3], -1.0, ylow)
-    zhigh = np.where(inside[:, 4], 1.0, zhigh)
-    zlow = np.where(inside[:, 5], -1.0, zlow)
+    # will be either 1 or -1 on the unit sphere). _AXIS_POINTS alternates between the two
+    # ends of an axis, so the even entries are the +1 ends and the odd ones the -1 ends.
+    high = np.where(inside[..., 0::2], 1.0, high)
+    low = np.where(inside[..., 1::2], -1.0, low)
 
     # --- Step 3: per-edge extrema ------------------------------------------------
-    # Loop on the vertex combinations that make up each face
-    for a, b in ((v0, v1), (v1, v2), (v2, v0)):
+    # Loop on the pairs of adjacent nodes that make up each face's edges, wrapping
+    # from the last node back to the first.
+    for node in range(nodes_per_face):
+        a = verts[..., node, :]
+        b = verts[..., (node + 1) % nodes_per_face, :]
         # Compute the total angular length of the arc created by points a and b
-        cos_delta = np.clip(np.sum(a * b, axis=-1), -1.0, 1.0)  # (nfaces,)
-        delta = np.arccos(cos_delta)  # (nfaces,)
+        cos_delta = np.clip(np.sum(a * b, axis=-1), -1.0, 1.0)  # (...)
+        delta = np.arccos(cos_delta)  # (...)
 
-        # Construct a unit vector perpendicular to a points towards b. (a, u) then
+        # Construct a unit vector perpendicular to a that points towards b. (a, u) then
         # forms an orthonormal basis for that plane, so any point on the arc created
         # by the vertices (a,b) is in that plane, and can be computed as cos(theta)*a + sin(theta)*u
         # for theta in [0, delta]. theta=0 recovers a and theta=delta recovers b.
-        u = b - cos_delta[:, None] * a
-        u = u / np.linalg.norm(u, axis=-1)[:, None]
+        u = b - cos_delta[..., None] * a
+        edge_length = np.linalg.norm(u, axis=-1)
+        # An edge between two identical nodes has no direction to normalize; dividing
+        # the resulting zero vector by 1 keeps it zero rather than making it NaN.
+        u = u / np.where(edge_length == 0.0, 1.0, edge_length)[..., None]
 
         # Using the identity Acos(theta) + Bsin(theta) = Rcos(theta - phi) where
-        # R is an amplitude R = sqrt(A^2 + B^2) and phi = arctan2(B, A). The edges
-        # max or min then given by the location where theta=0, pi, plus the phase
+        # R is an amplitude R = sqrt(A^2 + B^2) and phi = arctan2(B, A). The edge's
+        # max or min are then given by the location where theta=0, pi, plus the phase
         # shift of phi.
-        amp = np.hypot(a, u)  # (nfaces, 3): wave amplitude R, per coordinate
-        phase = np.arctan2(u, a)  # (nfaces, 3): wave phase phi, per coordinate
+        amp = np.hypot(a, u)  # (..., 3): wave amplitude R, per coordinate
+        phase = np.arctan2(u, a)  # (..., 3): wave phase phi, per coordinate
 
-        # Compute the values of theta that result in a bounding box extrema.
-        theta_max = phase % (2 * np.pi)  # (nfaces, 3)
-        theta_min = (phase + np.pi) % (2 * np.pi)  # (nfaces, 3)
+        # Compute the values of theta that result in a bounding box extremum.
+        theta_max = phase % (2 * np.pi)  # (..., 3)
+        theta_min = (phase + np.pi) % (2 * np.pi)  # (..., 3)
 
-        # Calculate whether or not an extrema generating theta falls into the
+        # Calculate whether or not an extremum-generating theta falls into the
         # arc constructed by each edge.
-        valid_max = theta_max <= delta[:, None]  # (nfaces, 3)
-        valid_min = theta_min <= delta[:, None]  # (nfaces, 3)
+        valid_max = theta_max <= delta[..., None]  # (..., 3)
+        valid_min = theta_min <= delta[..., None]  # (..., 3)
 
-        # For theta that fall on the arc of each edge, construct and array of
-        # amplitudes representing the new candidate bound.
-        candidate_high = np.where(valid_max, amp, -np.inf)  # (nfaces, 3)
-        candidate_low = np.where(valid_min, -amp, np.inf)  # (nfaces, 3)
+        # For theta that fall on the arc of each edge, keep whichever is more extreme:
+        # the currently computed bound, or this edge's candidate for that coordinate.
+        high = np.maximum(high, np.where(valid_max, amp, -np.inf))
+        low = np.minimum(low, np.where(valid_min, -amp, np.inf))
 
-        # Keep whichever is more extreme: the currently computed bound, or this edge's
-        # candidate for that coordinate.
-        xhigh = np.maximum(xhigh, candidate_high[:, 0])
-        yhigh = np.maximum(yhigh, candidate_high[:, 1])
-        zhigh = np.maximum(zhigh, candidate_high[:, 2])
-        xlow = np.minimum(xlow, candidate_low[:, 0])
-        ylow = np.minimum(ylow, candidate_low[:, 1])
-        zlow = np.minimum(zlow, candidate_low[:, 2])
-
-    return xlow, xhigh, ylow, yhigh, zlow, zhigh
+    return low[..., 0], high[..., 0], low[..., 1], high[..., 1], low[..., 2], high[..., 2]
 
 
 def quantize_coordinates(x, y, z, xmin, xmax, ymin, ymax, zmin, zmax, bitwidth=1023):

--- a/src/parcels/_core/spatialhash.py
+++ b/src/parcels/_core/spatialhash.py
@@ -171,8 +171,8 @@ class SpatialHash:
                 vx, vy, vz = _latlon_rad_to_xyz(np.deg2rad(lat), np.deg2rad(lon))
                 verts = np.stack([vx, vy, vz], axis=-1)  # (nfaces, 3 nodes, 3)
 
-                self._xlow, self._xhigh, self._ylow, self._yhigh, self._zlow, self._zhigh = (
-                    _spherical_triangle_bounds(verts)
+                self._xlow, self._xhigh, self._ylow, self._yhigh, self._zlow, self._zhigh = _spherical_triangle_bounds(
+                    verts
                 )
 
                 # Boundaries of the hash grid are the Cartesian bounding box of the
@@ -691,7 +691,6 @@ def _spherical_triangle_bounds(verts):
     -------
     xlow, xhigh, ylow, yhigh, zlow, zhigh : ndarray, shape (nfaces,)
     """
-
     # --- Step 1: Calculate the bounds from the nodes themselves ----
     v0, v1, v2 = verts[:, 0, :], verts[:, 1, :], verts[:, 2, :]
     nfaces = verts.shape[0]
@@ -722,7 +721,6 @@ def _spherical_triangle_bounds(verts):
         # Compute the total angular length of the arc created by points a and b
         cos_delta = np.clip(np.sum(a * b, axis=-1), -1.0, 1.0)  # (nfaces,)
         delta = np.arccos(cos_delta)  # (nfaces,)
-
 
         # Construct a unit vector perpendicular to a points towards b. (a, u) then
         # forms an orthonormal basis for that plane, so any point on the arc created

--- a/src/parcels/_core/spatialhash.py
+++ b/src/parcels/_core/spatialhash.py
@@ -78,8 +78,8 @@ class SpatialHash:
                 # Compute the exact bounding box of each face. A face's edges are
                 # great-circle arcs, so its true x/y/z extent is often not spanned by
                 # its node coordinates alone.
-                self._xlow, self._xhigh, self._ylow, self._yhigh, self._zlow, self._zhigh = (
-                    _spherical_face_bounds(verts)
+                self._xlow, self._xhigh, self._ylow, self._yhigh, self._zlow, self._zhigh = _spherical_face_bounds(
+                    verts
                 )
 
                 # Boundaries of the hash grid are the Cartesian bounding box of the

--- a/src/parcels/_core/spatialhash.py
+++ b/src/parcels/_core/spatialhash.py
@@ -168,24 +168,29 @@ class SpatialHash:
                 nids = self._source_grid.uxgrid.face_node_connectivity.values
                 lon = self._source_grid.uxgrid.node_lon.values[nids]
                 lat = self._source_grid.uxgrid.node_lat.values[nids]
-                _xbound, _ybound, _zbound = _latlon_rad_to_xyz(np.deg2rad(lat), np.deg2rad(lon))
+                vx, vy, vz = _latlon_rad_to_xyz(np.deg2rad(lat), np.deg2rad(lon))
+                verts = np.stack([vx, vy, vz], axis=-1)  # (nfaces, 3 nodes, 3)
+
+                self._xlow, self._xhigh, self._ylow, self._yhigh, self._zlow, self._zhigh = (
+                    _spherical_triangle_bounds(verts)
+                )
+
                 # Boundaries of the hash grid are the Cartesian bounding box of the
                 # transformed grid, so that regional domains retain full quantization
                 # resolution instead of spreading it over the whole unit cube
-                self._xmin = _xbound.min()
-                self._xmax = _xbound.max()
-                self._ymin = _ybound.min()
-                self._ymax = _ybound.max()
-                self._zmin = _zbound.min()
-                self._zmax = _zbound.max()
+                self._xmin = self._xlow.min()
+                self._xmax = self._xhigh.max()
+                self._ymin = self._ylow.min()
+                self._ymax = self._yhigh.max()
+                self._zmin = self._zlow.min()
+                self._zmax = self._zhigh.max()
 
-                # Compute bounding box of each face
-                self._xlow = np.atleast_2d(np.min(_xbound, axis=-1))
-                self._xhigh = np.atleast_2d(np.max(_xbound, axis=-1))
-                self._ylow = np.atleast_2d(np.min(_ybound, axis=-1))
-                self._yhigh = np.atleast_2d(np.max(_ybound, axis=-1))
-                self._zlow = np.atleast_2d(np.min(_zbound, axis=-1))
-                self._zhigh = np.atleast_2d(np.max(_zbound, axis=-1))
+                self._xlow = np.atleast_2d(self._xlow)
+                self._xhigh = np.atleast_2d(self._xhigh)
+                self._ylow = np.atleast_2d(self._ylow)
+                self._yhigh = np.atleast_2d(self._yhigh)
+                self._zlow = np.atleast_2d(self._zlow)
+                self._zhigh = np.atleast_2d(self._zhigh)
 
             else:
                 # Boundaries of the hash grid are the bounding box of the source grid
@@ -642,6 +647,121 @@ def _find_degenerate_xgrid_faces(x, y, z, threshold_factor=10):
 
     threshold = threshold_factor * np.percentile(max_chord, 99)
     return max_chord > threshold
+
+
+# The 6 points where x, y, or z reaches its absolute max/min over the whole unit
+# sphere: the poles (+-z) and the equator/prime-meridian crossings (+-x, +-y).
+_AXIS_POINTS = np.array(
+    [
+        [1.0, 0.0, 0.0],
+        [-1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, -1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 0.0, -1.0],
+    ]
+)
+
+
+def _spherical_triangle_bounds(verts):
+    """Exact per-face x/y/z bounding box for triangular faces on the unit sphere,
+    computed in closed form (no sampling).
+
+    A face's edges are great-circle arcs, so the true min/max of x, y, or z
+    reached anywhere on a face is often not one of its node coordinates. The
+    surface can bulge past every node along an edge, or, for a face containing a
+    pole or an equator/prime-meridian crossing, reach its extreme at a single
+    interior point. The spatial hash grid must include these points. They are
+    computed based on the assumption that a face's extrema sit at one of the following:
+
+      1. The nodes themselves.
+      2. Any of the 6 points in `_AXIS_POINTS` that could lie inside the face. If this
+         is the case then that particular face's extrema is +-1 for that particular bound.
+      3. For each edge, the point(s) along that great-circle arc where x, y, or z
+         is extremized. This extreme does not fall on a node when a cos representing
+         the point in space hits a min/max.
+
+    Parameters
+    ----------
+    verts : ndarray, shape (nfaces, 3, 3)
+        Unit-sphere xyz coordinates of each face's 3 nodes, in winding order.
+        The last axis is (x, y, z).
+
+    Returns
+    -------
+    xlow, xhigh, ylow, yhigh, zlow, zhigh : ndarray, shape (nfaces,)
+    """
+
+    # --- Step 1: Calculate the bounds from the nodes themselves ----
+    v0, v1, v2 = verts[:, 0, :], verts[:, 1, :], verts[:, 2, :]
+    nfaces = verts.shape[0]
+
+    xlow, ylow, zlow = np.min(verts, axis=1).T
+    xhigh, yhigh, zhigh = np.max(verts, axis=1).T
+
+    # --- Step 2: Check which faces the global extrema fall into (using a gnomonic projection) ---
+    M = np.stack([v0, v1, v2], axis=-1)  # (nfaces, 3, 3), columns v0, v1, v2
+    rhs = np.broadcast_to(_AXIS_POINTS.T, (nfaces, 3, 6))
+    w = np.linalg.solve(M, rhs)  # (nfaces, 3, 6): weights per axis point
+
+    # An axis point is in a face if its weights are >=0 (1e-12 accounts for machine precision).
+    inside = np.all(w >= -1e-12, axis=1)  # (nfaces, 6)
+
+    # For faces that contain a global extreme point, override the bound to use that point (which
+    # will be either 1 or -1 on the unit sphere).
+    xhigh = np.where(inside[:, 0], 1.0, xhigh)
+    xlow = np.where(inside[:, 1], -1.0, xlow)
+    yhigh = np.where(inside[:, 2], 1.0, yhigh)
+    ylow = np.where(inside[:, 3], -1.0, ylow)
+    zhigh = np.where(inside[:, 4], 1.0, zhigh)
+    zlow = np.where(inside[:, 5], -1.0, zlow)
+
+    # --- Step 3: per-edge extrema ------------------------------------------------
+    # Loop on the vertex combinations that make up each face
+    for a, b in ((v0, v1), (v1, v2), (v2, v0)):
+        # Compute the total angular length of the arc created by points a and b
+        cos_delta = np.clip(np.sum(a * b, axis=-1), -1.0, 1.0)  # (nfaces,)
+        delta = np.arccos(cos_delta)  # (nfaces,)
+
+
+        # Construct a unit vector perpendicular to a points towards b. (a, u) then
+        # forms an orthonormal basis for that plane, so any point on the arc created
+        # by the vertices (a,b) is in that plane, and can be computed as cos(theta)*a + sin(theta)*u
+        # for theta in [0, delta]. theta=0 recovers a and theta=delta recovers b.
+        u = b - cos_delta[:, None] * a
+        u = u / np.linalg.norm(u, axis=-1)[:, None]
+
+        # Using the identity Acos(theta) + Bsin(theta) = Rcos(theta - phi) where
+        # R is an amplitude R = sqrt(A^2 + B^2) and phi = arctan2(B, A). The edges
+        # max or min then given by the location where theta=0, pi, plus the phase
+        # shift of phi.
+        amp = np.hypot(a, u)  # (nfaces, 3): wave amplitude R, per coordinate
+        phase = np.arctan2(u, a)  # (nfaces, 3): wave phase phi, per coordinate
+
+        # Compute the values of theta that result in a bounding box extrema.
+        theta_max = phase % (2 * np.pi)  # (nfaces, 3)
+        theta_min = (phase + np.pi) % (2 * np.pi)  # (nfaces, 3)
+
+        # Calculate whether or not an extrema generating theta falls into the
+        # arc constructed by each edge.
+        valid_max = theta_max <= delta[:, None]  # (nfaces, 3)
+        valid_min = theta_min <= delta[:, None]  # (nfaces, 3)
+
+        # For theta that fall on the arc of each edge, construct and array of
+        # amplitudes representing the new candidate bound.
+        candidate_high = np.where(valid_max, amp, -np.inf)  # (nfaces, 3)
+        candidate_low = np.where(valid_min, -amp, np.inf)  # (nfaces, 3)
+
+        # Keep whichever is more extreme: the currently computed bound, or this edge's
+        # candidate for that coordinate.
+        xhigh = np.maximum(xhigh, candidate_high[:, 0])
+        yhigh = np.maximum(yhigh, candidate_high[:, 1])
+        zhigh = np.maximum(zhigh, candidate_high[:, 2])
+        xlow = np.minimum(xlow, candidate_low[:, 0])
+        ylow = np.minimum(ylow, candidate_low[:, 1])
+        zlow = np.minimum(zlow, candidate_low[:, 2])
+
+    return xlow, xhigh, ylow, yhigh, zlow, zhigh
 
 
 def quantize_coordinates(x, y, z, xmin, xmax, ymin, ymax, zmin, zmax, bitwidth=1023):

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -2,8 +2,9 @@ import numpy as np
 import pytest
 
 from parcels._core.fieldset import FieldSet
-from parcels._core.index_search import _search_indices_curvilinear_2d
+from parcels._core.index_search import _search_indices_curvilinear_2d, uxgrid_point_in_cell
 from parcels._datasets.structured.generic import datasets
+from tests.utils import create_uxgrid_triangulated_patch, sample_points_inside_faces
 
 
 @pytest.fixture
@@ -43,3 +44,67 @@ def test_grid_indexing_fpoints(field_cone):
             ]
             assert x > np.min(cell_lon) and x < np.max(cell_lon)
             assert y > np.min(cell_lat) and y < np.max(cell_lat)
+
+
+def _near_edge_barycentric_weights(offset):
+    """Weights for points just inside each edge; ``offset`` goes to the opposite vertex.
+
+    The rest is split unevenly so samples avoid edge midpoints.
+    """
+    rest = 1.0 - offset
+    return np.array(
+        [
+            [offset, rest * 0.61, rest * 0.39],
+            [rest * 0.61, offset, rest * 0.39],
+            [rest * 0.39, rest * 0.61, offset],
+        ]
+    )
+
+
+# One interior point plus three a hair inside the edges, which is where the projection
+# defect bites and where a particle crossing between faces sits.
+_POINT_IN_CELL_WEIGHTS = np.vstack(
+    [
+        [[1 / 3, 1 / 3, 1 / 3]],
+        _near_edge_barycentric_weights(1e-4),
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    ("face_deg", "n"),
+    [
+        pytest.param(1.0, 8, id="1deg"),
+        pytest.param(5.0, 8, id="5deg"),
+        pytest.param(15.0, 4, id="15deg"),
+        pytest.param(25.0, 4, id="25deg-notebook-scale"),
+    ],
+)
+@pytest.mark.xfail(reason="#2878 - orthogonal, not radial, projection onto the face plane")
+def test_uxgrid_point_in_cell_locates_interior_points_of_large_faces(face_deg, n):
+    """``uxgrid_point_in_cell`` must accept a point inside the face it is given.
+
+    The spherical branch projects onto the face plane along the normal; membership is
+    defined by the ray from the origin, so the projection must be radial (gnomonic).
+    The error scales with face size times proximity to an edge, not face size alone.
+
+    The face index is passed in directly, bypassing the hash, so the bounding-box
+    defect cannot influence the result. The tolerance on the coordinate sum is far
+    tighter than the ``rtol=1e-3`` gate in the source: radial projection makes the sum
+    exactly 1, so this pins the fix to the projection rather than to a looser gate.
+    """
+    grid, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=(25.0, 10.0), n=n, mesh="spherical")
+    lon, lat, expected_face = sample_points_inside_faces(nodes, faces, weights=_POINT_IN_CELL_WEIGHTS)
+
+    is_in_cell, coords = uxgrid_point_in_cell(grid, lat, lon, expected_face, expected_face)
+
+    coord_sum = coords.sum(axis=1)
+    worst = int(np.argmax(np.abs(coord_sum - 1.0)))
+    assert np.allclose(coord_sum, 1.0, rtol=1e-6, atol=1e-6), (
+        f"barycentric coordinates of interior points do not sum to 1; worst is "
+        f"{coord_sum[worst]:.6f} at (lon, lat)=({lon[worst]:.3f}, {lat[worst]:.3f}) "
+        f"in face {expected_face[worst]}"
+    )
+
+    n_rejected = int(np.count_nonzero(is_in_cell == 0))
+    assert n_rejected == 0, f"{n_rejected} of {len(lon)} points were rejected from the face containing them"

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -61,8 +61,9 @@ def _near_edge_barycentric_weights(offset):
     )
 
 
-# One interior point plus three a hair inside the edges, which is where the projection
-# defect bites and where a particle crossing between faces sits.
+# One interior point plus three a hair inside the edges -- edge-hugging points are most
+# sensitive to projection accuracy, and are where a particle crossing between faces
+# actually sits.
 _POINT_IN_CELL_WEIGHTS = np.vstack(
     [
         [[1 / 3, 1 / 3, 1 / 3]],
@@ -77,21 +78,19 @@ _POINT_IN_CELL_WEIGHTS = np.vstack(
         pytest.param(1.0, 8, id="1deg"),
         pytest.param(5.0, 8, id="5deg"),
         pytest.param(15.0, 4, id="15deg"),
-        pytest.param(25.0, 4, id="25deg-notebook-scale"),
+        pytest.param(25.0, 4, id="25deg-large-scale"),
     ],
 )
-@pytest.mark.xfail(reason="#2878 - orthogonal, not radial, projection onto the face plane")
 def test_uxgrid_point_in_cell_locates_interior_points_of_large_faces(face_deg, cells_per_side):
     """``uxgrid_point_in_cell`` must accept a point inside the face it is given.
 
-    The spherical branch projects onto the face plane along the normal; membership is
-    defined by the ray from the origin, so the projection must be radial (gnomonic).
-    The error scales with face size times proximity to an edge, not face size alone.
+    The spherical branch's barycentric coordinates come from a gnomonic (radial)
+    projection: membership is defined by the ray from the sphere's center through
+    the point. Coordinates must sum to (very nearly) 1, and every point must be
+    accepted.
 
     The face index is passed in directly, bypassing the hash, so the bounding-box
-    defect cannot influence the result. The tolerance on the coordinate sum is far
-    tighter than the ``rtol=1e-3`` gate in the source: radial projection makes the sum
-    exactly 1, so this pins the fix to the projection rather than to a looser gate.
+    computation cannot influence the result.
     """
     grid, nodes, faces = create_uxgrid_triangulated_patch(
         face_deg, centre=(25.0, 10.0), n=cells_per_side, mesh="spherical"

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -4,7 +4,7 @@ import pytest
 from parcels._core.fieldset import FieldSet
 from parcels._core.index_search import _search_indices_curvilinear_2d, uxgrid_point_in_cell
 from parcels._datasets.structured.generic import datasets
-from tests.utils import create_uxgrid_triangulated_patch, sample_points_inside_faces
+from tests.utils import create_lonlat_patch, create_uxgrid_from_triangulation, sample_points_inside_faces
 
 
 @pytest.fixture
@@ -92,9 +92,8 @@ def test_uxgrid_point_in_cell_locates_interior_points_of_large_faces(face_deg, c
     The face index is passed in directly, bypassing the hash, so the bounding-box
     computation cannot influence the result.
     """
-    grid, nodes, faces = create_uxgrid_triangulated_patch(
-        face_deg, centre=(25.0, 10.0), n=cells_per_side, mesh="spherical"
-    )
+    nodes, faces = create_lonlat_patch(face_deg, centre=(25.0, 10.0), n=cells_per_side)
+    grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh="spherical")
     lon, lat, expected_face = sample_points_inside_faces(nodes, faces, weights=_POINT_IN_CELL_WEIGHTS)
 
     is_in_cell, coords = uxgrid_point_in_cell(grid, lat, lon, expected_face, expected_face)

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -2,9 +2,13 @@ import numpy as np
 import pytest
 
 from parcels._core.fieldset import FieldSet
-from parcels._core.index_search import _search_indices_curvilinear_2d, uxgrid_point_in_cell
+from parcels._core.index_search import (
+    _search_indices_curvilinear_2d,
+    curvilinear_point_in_cell,
+    uxgrid_point_in_cell,
+)
 from parcels._datasets.structured.generic import datasets
-from tests.utils import create_lonlat_patch, create_uxgrid_from_triangulation, sample_points_inside_faces
+from tests.utils import create_lonlat_grid, sample_points_inside_faces
 
 
 @pytest.fixture
@@ -46,32 +50,25 @@ def test_grid_indexing_fpoints(field_cone):
             assert y > np.min(cell_lat) and y < np.max(cell_lat)
 
 
-def _near_edge_barycentric_weights(offset):
-    """Weights for points just inside each edge; ``offset`` goes to the opposite vertex.
+def _point_in_cell_weights(nodes_per_face, offset=1e-4):
+    """One point at the centre of a face plus one a hair inside each of its edges.
 
-    The rest is split unevenly so samples avoid edge midpoints.
+    An edge's two nodes share whatever is left after every other node takes ``offset``,
+    split unevenly so the samples avoid edge midpoints. Edge-hugging points are the most
+    sensitive to projection accuracy, and are where a particle crossing between faces
+    actually sits.
     """
-    rest = 1.0 - offset
-    return np.array(
-        [
-            [offset, rest * 0.61, rest * 0.39],
-            [rest * 0.61, offset, rest * 0.39],
-            [rest * 0.39, rest * 0.61, offset],
-        ]
-    )
+    near_edge = np.full((nodes_per_face, nodes_per_face), offset)
+    rest = 1.0 - offset * (nodes_per_face - 2)
+    for edge, weights in enumerate(near_edge):
+        weights[edge] = rest * 0.61
+        weights[(edge + 1) % nodes_per_face] = rest * 0.39
+
+    centre = np.full((1, nodes_per_face), 1.0 / nodes_per_face)
+    return np.vstack([centre, near_edge])
 
 
-# One interior point plus three a hair inside the edges -- edge-hugging points are most
-# sensitive to projection accuracy, and are where a particle crossing between faces
-# actually sits.
-_POINT_IN_CELL_WEIGHTS = np.vstack(
-    [
-        [[1 / 3, 1 / 3, 1 / 3]],
-        _near_edge_barycentric_weights(1e-4),
-    ]
-)
-
-
+@pytest.mark.parametrize("grid_type", ["uxgrid", "xgrid"])
 @pytest.mark.parametrize(
     ("face_deg", "cells_per_side"),
     [
@@ -81,30 +78,35 @@ _POINT_IN_CELL_WEIGHTS = np.vstack(
         pytest.param(25.0, 4, id="25deg-large-scale"),
     ],
 )
-def test_uxgrid_point_in_cell_locates_interior_points_of_large_faces(face_deg, cells_per_side):
-    """``uxgrid_point_in_cell`` must accept a point inside the face it is given.
+def test_point_in_cell_locates_interior_points_of_large_faces(grid_type, face_deg, cells_per_side):
+    """A point-in-cell check must accept a point inside the face it is given."""
+    grid, nodes, faces = create_lonlat_grid(grid_type, face_deg, centre=(25.0, 10.0), n=cells_per_side)
+    weights = _point_in_cell_weights(faces.shape[1])
+    lon, lat, expected_face = sample_points_inside_faces(nodes, faces, weights=weights)
 
-    The spherical branch's barycentric coordinates come from a gnomonic (radial)
-    projection: membership is defined by the ray from the sphere's center through
-    the point. Coordinates must sum to (very nearly) 1, and every point must be
-    accepted.
+    # A UxGrid indexes its faces in one flat list, so unraveling leaves yi at 0 and puts
+    # the face id in xi (which is all uxgrid_point_in_cell reads); an XGrid's cells are a
+    # 2-D lattice, so both indexes matter.
+    cell_shape = (1, len(faces)) if grid_type == "uxgrid" else (cells_per_side, cells_per_side)
+    yi, xi = np.unravel_index(expected_face, cell_shape)
 
-    The face index is passed in directly, bypassing the hash, so the bounding-box
-    computation cannot influence the result.
-    """
-    nodes, faces = create_lonlat_patch(face_deg, centre=(25.0, 10.0), n=cells_per_side)
-    grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh="spherical")
-    lon, lat, expected_face = sample_points_inside_faces(nodes, faces, weights=_POINT_IN_CELL_WEIGHTS)
+    point_in_cell = uxgrid_point_in_cell if grid_type == "uxgrid" else curvilinear_point_in_cell
+    is_in_cell, coords = point_in_cell(grid, lat, lon, yi, xi)
 
-    is_in_cell, coords = uxgrid_point_in_cell(grid, lat, lon, expected_face, expected_face)
-
-    coord_sum = coords.sum(axis=1)
-    worst = int(np.argmax(np.abs(coord_sum - 1.0)))
-    assert np.allclose(coord_sum, 1.0, rtol=1e-6, atol=1e-6), (
-        f"barycentric coordinates of interior points do not sum to 1; worst is "
-        f"{coord_sum[worst]:.6f} at (lon, lat)=({lon[worst]:.3f}, {lat[worst]:.3f}) "
-        f"in face {expected_face[worst]}"
+    rejected = is_in_cell == 0
+    n_rejected = int(np.count_nonzero(rejected))
+    assert n_rejected == 0, (
+        f"{n_rejected} of {len(lon)} points were rejected from the face containing them; e.g. "
+        f"(lon, lat)={np.column_stack((lon, lat))[rejected][:3].tolist()}"
     )
 
-    n_rejected = int(np.count_nonzero(is_in_cell == 0))
-    assert n_rejected == 0, f"{n_rejected} of {len(lon)} points were rejected from the face containing them"
+    if grid_type == "uxgrid":
+        # Barycentric coordinates are normalized to sum to 1. The curvilinear branch
+        # returns (xsi, eta) bilinear weights instead, which carry no such invariant.
+        coord_sum = coords.sum(axis=1)
+        worst = int(np.argmax(np.abs(coord_sum - 1.0)))
+        assert np.allclose(coord_sum, 1.0, rtol=1e-6, atol=1e-6), (
+            f"barycentric coordinates of interior points do not sum to 1; worst is "
+            f"{coord_sum[worst]:.6f} at (lon, lat)=({lon[worst]:.3f}, {lat[worst]:.3f}) "
+            f"in face {expected_face[worst]}"
+        )

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -72,7 +72,7 @@ _POINT_IN_CELL_WEIGHTS = np.vstack(
 
 
 @pytest.mark.parametrize(
-    ("face_deg", "n"),
+    ("face_deg", "cells_per_side"),
     [
         pytest.param(1.0, 8, id="1deg"),
         pytest.param(5.0, 8, id="5deg"),
@@ -81,7 +81,7 @@ _POINT_IN_CELL_WEIGHTS = np.vstack(
     ],
 )
 @pytest.mark.xfail(reason="#2878 - orthogonal, not radial, projection onto the face plane")
-def test_uxgrid_point_in_cell_locates_interior_points_of_large_faces(face_deg, n):
+def test_uxgrid_point_in_cell_locates_interior_points_of_large_faces(face_deg, cells_per_side):
     """``uxgrid_point_in_cell`` must accept a point inside the face it is given.
 
     The spherical branch projects onto the face plane along the normal; membership is
@@ -93,7 +93,9 @@ def test_uxgrid_point_in_cell_locates_interior_points_of_large_faces(face_deg, n
     tighter than the ``rtol=1e-3`` gate in the source: radial projection makes the sum
     exactly 1, so this pins the fix to the projection rather than to a looser gate.
     """
-    grid, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=(25.0, 10.0), n=n, mesh="spherical")
+    grid, nodes, faces = create_uxgrid_triangulated_patch(
+        face_deg, centre=(25.0, 10.0), n=cells_per_side, mesh="spherical"
+    )
     lon, lat, expected_face = sample_points_inside_faces(nodes, faces, weights=_POINT_IN_CELL_WEIGHTS)
 
     is_in_cell, coords = uxgrid_point_in_cell(grid, lat, lon, expected_face, expected_face)

--- a/tests/test_spatialhash.py
+++ b/tests/test_spatialhash.py
@@ -1,10 +1,18 @@
 from io import StringIO
 
 import numpy as np
+import pytest
 
 from parcels._core.fieldset import FieldSet
+from parcels._core.index_search import _latlon_rad_to_xyz
 from parcels._core.spatialhash import _HASH_ENTRIES_PER_FACE, _HASH_ENTRY_BUDGET_MIN
 from parcels._datasets.structured.generic import datasets
+from tests.utils import (
+    cartesian_face_bounds_from_vertices,
+    create_uxgrid_from_triangulation,
+    create_uxgrid_triangulated_patch,
+    sample_points_inside_faces,
+)
 
 
 def _cell_centers(grid):
@@ -176,3 +184,56 @@ def test_nan_node_invalidates_touching_faces():
     j_rest, i_rest, _ = spatialhash.query(clat[mask], clon[mask])
     assert np.array_equal(j_rest, jj[mask])
     assert np.array_equal(i_rest, ii[mask])
+
+
+_SPHERICAL_FACE_CASES = [
+    # Resolution-independent failure: the face straddles a stationary point of a
+    # Cartesian coordinate, so its interior extremum is invisible to the vertices.
+    pytest.param(1.0, (0.0, 0.0), id="1deg-at-cartesian-stationary-point"),
+    # Away from a stationary point the gap is O(face**2), so only large faces fail.
+    pytest.param(15.0, (40.0, 30.0), id="15deg-away-from-stationary-point"),
+    pytest.param(25.0, (25.0, 10.0), id="25deg-notebook-scale"),
+]
+
+
+@pytest.mark.parametrize(("face_deg", "centre"), _SPHERICAL_FACE_CASES)
+@pytest.mark.xfail(reason="#2878 - spherical face bounding boxes are built from vertices only")
+def test_spherical_uxgrid_face_bounds_contain_face_interior(face_deg, centre):
+    """A face's Cartesian bounding box must contain the whole face, not just its vertices.
+
+    Asserts on box geometry only, so the point-in-cell defect cannot mask this one.
+    """
+    grid, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=centre, mesh="spherical")
+    lon, lat, expected_face = sample_points_inside_faces(nodes, faces)
+
+    low, high = cartesian_face_bounds_from_vertices(grid)
+    query = np.stack(_latlon_rad_to_xyz(np.deg2rad(lat), np.deg2rad(lon)), axis=-1)
+
+    inside_box = np.all((query >= low[expected_face]) & (query <= high[expected_face]), axis=1)
+    n_outside = int(np.count_nonzero(~inside_box))
+    assert n_outside == 0, (
+        f"{n_outside} of {len(lon)} points lie inside their face but outside that face's "
+        f"Cartesian bounding box; e.g. (lon, lat)="
+        f"{np.column_stack((lon, lat))[~inside_box][:3].tolist()}"
+    )
+
+
+@pytest.mark.parametrize(("face_deg", "centre"), _SPHERICAL_FACE_CASES)
+@pytest.mark.xfail(reason="#2878 - spherical face bounding boxes are built from vertices only")
+def test_spherical_uxgrid_hash_locates_every_interior_point(face_deg, centre):
+    """End-to-end symptom: the hash loses points that lie inside a face.
+
+    The flat build of the same triangulation must locate them all, which shows the
+    fixture is sound and the defect is specific to the spherical path.
+    """
+    _, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=centre, mesh="flat")
+    lon, lat, _ = sample_points_inside_faces(nodes, faces)
+
+    flat_grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh="flat")
+    _, flat_face, _ = flat_grid.get_spatial_hash().query(lat, lon)
+    assert np.all(flat_face >= 0), "flat-mesh search lost points, so the test fixture itself is suspect"
+
+    spherical_grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh="spherical")
+    _, spherical_face, _ = spherical_grid.get_spatial_hash().query(lat, lon)
+    n_lost = int(np.count_nonzero(spherical_face < 0))
+    assert n_lost == 0, f"spherical search failed to locate {n_lost} of {len(lon)} interior points"

--- a/tests/test_spatialhash.py
+++ b/tests/test_spatialhash.py
@@ -186,17 +186,16 @@ def test_nan_node_invalidates_touching_faces():
 
 
 _SPHERICAL_FACE_CASES = [
-    pytest.param(1.0, (0.3, 0.6), id="1deg-small-scale"),
-    pytest.param(15.0, (40.0, 30.0), id="15deg-medium-scale"),
-    pytest.param(25.0, (25.0, 10.0), id="25deg-large-scale"),
+    pytest.param(1.0, 8, (0.3, 0.6), id="1deg-small-scale"),
+    pytest.param(15.0, 4, (40.0, 30.0), id="15deg-medium-scale"),
+    pytest.param(25.0, 4, (25.0, 10.0), id="25deg-large-scale"),
 ]
 
 
-@pytest.mark.parametrize(("face_deg", "centre"), _SPHERICAL_FACE_CASES)
-def test_spherical_triangle_bounds_contains_face_interior(face_deg, centre):
+@pytest.mark.parametrize(("face_deg", "cells_per_side", "centre"), _SPHERICAL_FACE_CASES)
+def test_spherical_triangle_bounds_contains_face_interior(face_deg, cells_per_side, centre):
     """_spherical_triangle_bounds's per-face box must contain the whole face, not just its vertices."""
-    n = 4 if face_deg >= 15.0 else 8
-    _, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=centre, n=n, mesh="spherical")
+    _, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=centre, n=cells_per_side, mesh="spherical")
     lon, lat, expected_face = sample_points_inside_faces(nodes, faces)
 
     face_lon = np.deg2rad(nodes[faces, 0])
@@ -218,15 +217,12 @@ def test_spherical_triangle_bounds_contains_face_interior(face_deg, centre):
     )
 
 
-@pytest.mark.parametrize(("face_deg", "centre"), _SPHERICAL_FACE_CASES)
-@pytest.mark.xfail(reason="#2878 - spherical face bounding boxes are built from vertices only")
-def test_spherical_uxgrid_hash_locates_every_interior_point(face_deg, centre):
-    """End-to-end symptom: the hash loses points that lie inside a face.
-
-    The flat build of the same triangulation must locate them all, which shows the
-    fixture is sound and the defect is specific to the spherical path.
+@pytest.mark.parametrize(("face_deg", "cells_per_side", "centre"), _SPHERICAL_FACE_CASES)
+def test_spherical_uxgrid_hash_locates_every_interior_point(face_deg, cells_per_side, centre):
+    """End-to-end: SpatialHash.query() must locate every point known to lie inside a face,
+    on both a flat and a spherical build of the same triangulation.
     """
-    _, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=centre, mesh="flat")
+    _, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=centre, n=cells_per_side, mesh="spherical")
     lon, lat, _ = sample_points_inside_faces(nodes, faces)
 
     flat_grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh="flat")

--- a/tests/test_spatialhash.py
+++ b/tests/test_spatialhash.py
@@ -5,10 +5,9 @@ import pytest
 
 from parcels._core.fieldset import FieldSet
 from parcels._core.index_search import _latlon_rad_to_xyz
-from parcels._core.spatialhash import _HASH_ENTRIES_PER_FACE, _HASH_ENTRY_BUDGET_MIN
+from parcels._core.spatialhash import _HASH_ENTRIES_PER_FACE, _HASH_ENTRY_BUDGET_MIN, _spherical_triangle_bounds
 from parcels._datasets.structured.generic import datasets
 from tests.utils import (
-    cartesian_face_bounds_from_vertices,
     create_uxgrid_from_triangulation,
     create_uxgrid_triangulated_patch,
     sample_points_inside_faces,
@@ -187,33 +186,34 @@ def test_nan_node_invalidates_touching_faces():
 
 
 _SPHERICAL_FACE_CASES = [
-    # Resolution-independent failure: the face straddles a stationary point of a
-    # Cartesian coordinate, so its interior extremum is invisible to the vertices.
-    pytest.param(1.0, (0.0, 0.0), id="1deg-at-cartesian-stationary-point"),
-    # Away from a stationary point the gap is O(face**2), so only large faces fail.
-    pytest.param(15.0, (40.0, 30.0), id="15deg-away-from-stationary-point"),
-    pytest.param(25.0, (25.0, 10.0), id="25deg-notebook-scale"),
+    pytest.param(1.0, (0.3, 0.6), id="1deg-small-scale"),
+    pytest.param(15.0, (40.0, 30.0), id="15deg-medium-scale"),
+    pytest.param(25.0, (25.0, 10.0), id="25deg-large-scale"),
 ]
 
 
 @pytest.mark.parametrize(("face_deg", "centre"), _SPHERICAL_FACE_CASES)
-@pytest.mark.xfail(reason="#2878 - spherical face bounding boxes are built from vertices only")
-def test_spherical_uxgrid_face_bounds_contain_face_interior(face_deg, centre):
-    """A face's Cartesian bounding box must contain the whole face, not just its vertices.
-
-    Asserts on box geometry only, so the point-in-cell defect cannot mask this one.
-    """
-    grid, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=centre, mesh="spherical")
+def test_spherical_triangle_bounds_contains_face_interior(face_deg, centre):
+    """_spherical_triangle_bounds's per-face box must contain the whole face, not just its vertices."""
+    n = 4 if face_deg >= 15.0 else 8
+    _, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=centre, n=n, mesh="spherical")
     lon, lat, expected_face = sample_points_inside_faces(nodes, faces)
 
-    low, high = cartesian_face_bounds_from_vertices(grid)
+    face_lon = np.deg2rad(nodes[faces, 0])
+    face_lat = np.deg2rad(nodes[faces, 1])
+    verts = np.stack(_latlon_rad_to_xyz(face_lat, face_lon), axis=-1)  # (n_face, 3, 3)
+
+    xlow, xhigh, ylow, yhigh, zlow, zhigh = _spherical_triangle_bounds(verts)
+    low = np.stack([xlow, ylow, zlow], axis=-1)
+    high = np.stack([xhigh, yhigh, zhigh], axis=-1)
+
     query = np.stack(_latlon_rad_to_xyz(np.deg2rad(lat), np.deg2rad(lon)), axis=-1)
 
     inside_box = np.all((query >= low[expected_face]) & (query <= high[expected_face]), axis=1)
     n_outside = int(np.count_nonzero(~inside_box))
     assert n_outside == 0, (
         f"{n_outside} of {len(lon)} points lie inside their face but outside that face's "
-        f"Cartesian bounding box; e.g. (lon, lat)="
+        f"bounding box; e.g. (lon, lat)="
         f"{np.column_stack((lon, lat))[~inside_box][:3].tolist()}"
     )
 

--- a/tests/test_spatialhash.py
+++ b/tests/test_spatialhash.py
@@ -197,9 +197,7 @@ _SPHERICAL_FACE_CASES = [
 @pytest.mark.parametrize(("face_deg", "cells_per_side", "centre"), _SPHERICAL_FACE_CASES)
 def test_spherical_face_bounds_contains_face_interior(face_deg, cells_per_side, centre, nodes_per_face):
     """_spherical_face_bounds's per-face box must contain the whole face, not just its vertices."""
-    nodes, faces = create_lonlat_patch(
-        face_deg, centre=centre, n=cells_per_side, nodes_per_face=nodes_per_face
-    )
+    nodes, faces = create_lonlat_patch(face_deg, centre=centre, n=cells_per_side, nodes_per_face=nodes_per_face)
     lon, lat, expected_face = sample_points_inside_faces(nodes, faces)
 
     face_lon = np.deg2rad(nodes[faces, 0])
@@ -234,9 +232,7 @@ def test_spherical_face_bounds_ignores_faces_without_area():
     verts = np.stack(
         [
             np.stack(
-                _latlon_rad_to_xyz(
-                    np.deg2rad([node[1] for node in face]), np.deg2rad([node[0] for node in face])
-                ),
+                _latlon_rad_to_xyz(np.deg2rad([node[1] for node in face]), np.deg2rad([node[0] for node in face])),
                 axis=-1,
             )
             for face in faces_lonlat

--- a/tests/test_spatialhash.py
+++ b/tests/test_spatialhash.py
@@ -5,11 +5,12 @@ import pytest
 
 from parcels._core.fieldset import FieldSet
 from parcels._core.index_search import _latlon_rad_to_xyz
-from parcels._core.spatialhash import _HASH_ENTRIES_PER_FACE, _HASH_ENTRY_BUDGET_MIN, _spherical_triangle_bounds
+from parcels._core.spatialhash import _HASH_ENTRIES_PER_FACE, _HASH_ENTRY_BUDGET_MIN, _spherical_face_bounds
 from parcels._datasets.structured.generic import datasets
 from tests.utils import (
+    create_lonlat_patch,
     create_uxgrid_from_triangulation,
-    create_uxgrid_triangulated_patch,
+    create_xgrid_from_lonlat,
     sample_points_inside_faces,
 )
 
@@ -192,17 +193,20 @@ _SPHERICAL_FACE_CASES = [
 ]
 
 
+@pytest.mark.parametrize("nodes_per_face", [3, 4], ids=["triangles", "quads"])
 @pytest.mark.parametrize(("face_deg", "cells_per_side", "centre"), _SPHERICAL_FACE_CASES)
-def test_spherical_triangle_bounds_contains_face_interior(face_deg, cells_per_side, centre):
-    """_spherical_triangle_bounds's per-face box must contain the whole face, not just its vertices."""
-    _, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=centre, n=cells_per_side, mesh="spherical")
+def test_spherical_face_bounds_contains_face_interior(face_deg, cells_per_side, centre, nodes_per_face):
+    """_spherical_face_bounds's per-face box must contain the whole face, not just its vertices."""
+    nodes, faces = create_lonlat_patch(
+        face_deg, centre=centre, n=cells_per_side, nodes_per_face=nodes_per_face
+    )
     lon, lat, expected_face = sample_points_inside_faces(nodes, faces)
 
     face_lon = np.deg2rad(nodes[faces, 0])
     face_lat = np.deg2rad(nodes[faces, 1])
-    verts = np.stack(_latlon_rad_to_xyz(face_lat, face_lon), axis=-1)  # (n_face, 3, 3)
+    verts = np.stack(_latlon_rad_to_xyz(face_lat, face_lon), axis=-1)  # (n_face, nodes_per_face, 3)
 
-    xlow, xhigh, ylow, yhigh, zlow, zhigh = _spherical_triangle_bounds(verts)
+    xlow, xhigh, ylow, yhigh, zlow, zhigh = _spherical_face_bounds(verts)
     low = np.stack([xlow, ylow, zlow], axis=-1)
     high = np.stack([xhigh, yhigh, zhigh], axis=-1)
 
@@ -217,19 +221,67 @@ def test_spherical_triangle_bounds_contains_face_interior(face_deg, cells_per_si
     )
 
 
-@pytest.mark.parametrize(("face_deg", "cells_per_side", "centre"), _SPHERICAL_FACE_CASES)
-def test_spherical_uxgrid_hash_locates_every_interior_point(face_deg, cells_per_side, centre):
-    """End-to-end: SpatialHash.query() must locate every point known to lie inside a face,
-    on both a flat and a spherical build of the same triangulation.
+def test_spherical_face_bounds_ignores_faces_without_area():
+    """A face enclosing no area has no interior for an axis point to fall inside, so its
+    bounds must not be widened to +-1.
     """
-    _, nodes, faces = create_uxgrid_triangulated_patch(face_deg, centre=centre, n=cells_per_side, mesh="spherical")
-    lon, lat, _ = sample_points_inside_faces(nodes, faces)
+    faces_lonlat = [
+        # the last two nodes are the same point
+        [(40.0, 30.0), (40.05, 30.0), (40.05, 30.05), (40.05, 30.05)],
+        # every node on the equator, so all four sit on one great circle
+        [(40.0, 0.0), (40.03, 0.0), (40.08, 0.0), (40.02, 0.0)],
+    ]
+    verts = np.stack(
+        [
+            np.stack(
+                _latlon_rad_to_xyz(
+                    np.deg2rad([node[1] for node in face]), np.deg2rad([node[0] for node in face])
+                ),
+                axis=-1,
+            )
+            for face in faces_lonlat
+        ]
+    )
+    xlow, xhigh, ylow, yhigh, zlow, zhigh = _spherical_face_bounds(verts)
 
-    flat_grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh="flat")
-    _, flat_face, _ = flat_grid.get_spatial_hash().query(lat, lon)
-    assert np.all(flat_face >= 0), "flat-mesh search lost points, so the test fixture itself is suspect"
+    for low, high, axis in ((xlow, xhigh, "x"), (ylow, yhigh, "y"), (zlow, zhigh, "z")):
+        assert np.all(low > -1.0), f"a face with no area had its {axis} bound widened to -1"
+        assert np.all(high < 1.0), f"a face with no area had its {axis} bound widened to +1"
 
-    spherical_grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh="spherical")
-    _, spherical_face, _ = spherical_grid.get_spatial_hash().query(lat, lon)
-    n_lost = int(np.count_nonzero(spherical_face < 0))
-    assert n_lost == 0, f"spherical search failed to locate {n_lost} of {len(lon)} interior points"
+
+def _patch_grid(grid_type, face_deg, cells_per_side, centre, mesh):
+    """A patch of large faces, wrapped in the requested grid type.
+
+    A UxGrid takes a bare triangulation, while an XGrid takes the quads implied by its
+    2-D lattice of nodes, so the patch is cut to suit and the node list reshaped back
+    into a lattice for the structured case.
+
+    Returns ``(grid, nodes, faces)``.
+    """
+    nodes_per_face = 3 if grid_type == "uxgrid" else 4
+    nodes, faces = create_lonlat_patch(face_deg, centre=centre, n=cells_per_side, nodes_per_face=nodes_per_face)
+
+    if grid_type == "uxgrid":
+        grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh=mesh)
+    else:
+        side = cells_per_side + 1
+        grid = create_xgrid_from_lonlat(nodes[:, 0].reshape(side, side), nodes[:, 1].reshape(side, side), mesh=mesh)
+    return grid, nodes, faces
+
+
+@pytest.mark.parametrize("mesh", ["flat", "spherical"])
+@pytest.mark.parametrize("grid_type", ["uxgrid", "xgrid"])
+@pytest.mark.parametrize(("face_deg", "cells_per_side", "centre"), _SPHERICAL_FACE_CASES)
+def test_hash_locates_every_interior_point(grid_type, face_deg, cells_per_side, centre, mesh):
+    """End-to-end: SpatialHash.query() must return the face a point is known to lie inside."""
+    grid, nodes, faces = _patch_grid(grid_type, face_deg, cells_per_side, centre, mesh)
+    spatialhash = grid.get_spatial_hash()
+    lon, lat, expected_face = sample_points_inside_faces(nodes, faces, mesh=mesh)
+
+    j, i, _ = spatialhash.query(lat, lon)
+    # A UxGrid's bounds are one row of faces, so unraveling leaves j at 0 and puts the
+    # face id in i; an XGrid's are the (ny-1, nx-1) cell lattice, so both indexes matter.
+    expected_j, expected_i = np.unravel_index(expected_face, spatialhash._xlow.shape)
+
+    n_wrong = int(np.count_nonzero((j != expected_j) | (i != expected_i)))
+    assert n_wrong == 0, f"{mesh} search failed to locate {n_wrong} of {len(lon)} interior points"

--- a/tests/test_spatialhash.py
+++ b/tests/test_spatialhash.py
@@ -7,12 +7,7 @@ from parcels._core.fieldset import FieldSet
 from parcels._core.index_search import _latlon_rad_to_xyz
 from parcels._core.spatialhash import _HASH_ENTRIES_PER_FACE, _HASH_ENTRY_BUDGET_MIN, _spherical_face_bounds
 from parcels._datasets.structured.generic import datasets
-from tests.utils import (
-    create_lonlat_patch,
-    create_uxgrid_from_triangulation,
-    create_xgrid_from_lonlat,
-    sample_points_inside_faces,
-)
+from tests.utils import create_lonlat_grid, sample_points_inside_faces
 
 
 def _cell_centers(grid):
@@ -193,13 +188,11 @@ _SPHERICAL_FACE_CASES = [
 ]
 
 
-@pytest.mark.parametrize("nodes_per_face", [3, 4], ids=["triangles", "quads"])
+@pytest.mark.parametrize("grid_type", ["uxgrid", "xgrid"], ids=["triangles", "quads"])
 @pytest.mark.parametrize(("face_deg", "cells_per_side", "centre"), _SPHERICAL_FACE_CASES)
-def test_spherical_face_bounds_contains_face_interior(face_deg, cells_per_side, centre, nodes_per_face):
+def test_spherical_face_bounds_contains_face_interior(face_deg, cells_per_side, centre, grid_type):
     """_spherical_face_bounds's per-face box must contain the whole face, not just its vertices."""
-    nodes, faces = create_lonlat_patch(
-        face_deg, centre=centre, n=cells_per_side, nodes_per_face=nodes_per_face
-    )
+    _, nodes, faces = create_lonlat_grid(grid_type, face_deg, centre=centre, n=cells_per_side)
     lon, lat, expected_face = sample_points_inside_faces(nodes, faces)
 
     face_lon = np.deg2rad(nodes[faces, 0])
@@ -249,32 +242,12 @@ def test_spherical_face_bounds_ignores_faces_without_area():
         assert np.all(high < 1.0), f"a face with no area had its {axis} bound widened to +1"
 
 
-def _patch_grid(grid_type, face_deg, cells_per_side, centre, mesh):
-    """A patch of large faces, wrapped in the requested grid type.
-
-    A UxGrid takes a bare triangulation, while an XGrid takes the quads implied by its
-    2-D lattice of nodes, so the patch is cut to suit and the node list reshaped back
-    into a lattice for the structured case.
-
-    Returns ``(grid, nodes, faces)``.
-    """
-    nodes_per_face = 3 if grid_type == "uxgrid" else 4
-    nodes, faces = create_lonlat_patch(face_deg, centre=centre, n=cells_per_side, nodes_per_face=nodes_per_face)
-
-    if grid_type == "uxgrid":
-        grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh=mesh)
-    else:
-        side = cells_per_side + 1
-        grid = create_xgrid_from_lonlat(nodes[:, 0].reshape(side, side), nodes[:, 1].reshape(side, side), mesh=mesh)
-    return grid, nodes, faces
-
-
 @pytest.mark.parametrize("mesh", ["flat", "spherical"])
 @pytest.mark.parametrize("grid_type", ["uxgrid", "xgrid"])
 @pytest.mark.parametrize(("face_deg", "cells_per_side", "centre"), _SPHERICAL_FACE_CASES)
 def test_hash_locates_every_interior_point(grid_type, face_deg, cells_per_side, centre, mesh):
     """End-to-end: SpatialHash.query() must return the face a point is known to lie inside."""
-    grid, nodes, faces = _patch_grid(grid_type, face_deg, cells_per_side, centre, mesh)
+    grid, nodes, faces = create_lonlat_grid(grid_type, face_deg, centre=centre, n=cells_per_side, mesh=mesh)
     spatialhash = grid.get_spatial_hash()
     lon, lat, expected_face = sample_points_inside_faces(nodes, faces, mesh=mesh)
 

--- a/tests/test_uxarray_fieldset.py
+++ b/tests/test_uxarray_fieldset.py
@@ -15,6 +15,7 @@ from parcels.interpolators import (
     UxConstantFaceConstantZC,
     UxLinearNodeLinearZF,
 )
+from tests.utils import create_uxgrid_from_triangulation
 
 
 @pytest.fixture
@@ -149,3 +150,64 @@ def test_icon_evals():
     # value for interpolation is then just computed using query point locations
     # for the latitude and longitude, and the layer centers vertically.
     assert np.allclose(fieldset.p.eval(t=tq, z=zq, y=yq, x=xq), zc * (xq + yq))
+
+
+# Constrained (PSLG) Delaunay triangulation of the three nested polygons in
+# docs/user_guide/examples/tutorial_nestedgrids.ipynb, as produced by
+# triangle.triangulate({"vertices": ..., "segments": ...}, "p").
+#
+# Baked in as literals rather than recomputed: py-triangle is only in the "notebooks"
+# pixi feature, not "test", and the notebook's geometry is what #2878 is about, so
+# pinning it also stops the reproducer drifting if the triangulator changes.
+_NESTEDGRIDS_NODES = np.array(
+    [
+        [10.0, 15.0],
+        [25.0, 10.0],
+        [25.0, 25.0],
+        [17.0, 36.0],
+        [10.0, 32.0],
+        [0.0, -5.0],
+        [35.0, 0.0],
+        [35.0, 25.0],
+        [0.0, 20.0],
+        [-10.0, -20.0],
+        [60.0, -20.0],
+        [60.0, 40.0],
+        [-10.0, 40.0],
+        [25.0, 165.0 / 7.0],  # Steiner point added by the triangulator
+        [10.0, 150.0 / 7.0],  # Steiner point added by the triangulator
+    ]
+)
+_NESTEDGRIDS_FACES = np.array(
+    [
+        [8, 9, 5], [5, 9, 6], [0, 5, 1], [8, 5, 0], [12, 8, 4], [8, 12, 9],
+        [14, 8, 0], [12, 4, 3], [13, 14, 0], [14, 2, 4], [7, 1, 6], [6, 1, 5],
+        [10, 6, 9], [11, 6, 10], [3, 2, 7], [3, 4, 2], [7, 11, 3], [11, 7, 6],
+        [13, 1, 7], [3, 11, 12], [4, 8, 14], [13, 0, 1], [2, 14, 13], [7, 2, 13],
+    ]
+)  # fmt: skip
+
+
+@pytest.mark.xfail(reason="#2878 - see tests/test_spatialhash.py and tests/test_index_search.py for the two causes")
+def test_nestedgrids_notebook_triangulation_spherical_search():
+    """Every particle in tutorial_nestedgrids.ipynb must be located on a spherical mesh.
+
+    The notebook reduced to the grid-search step: same triangulation, same 500
+    positions, no fields or kernel. Covers the reported symptom; the two underlying
+    defects are covered separately by the tests named in the xfail reason.
+    """
+    grid = create_uxgrid_from_triangulation(
+        _NESTEDGRIDS_NODES[:, 0], _NESTEDGRIDS_NODES[:, 1], _NESTEDGRIDS_FACES, mesh="spherical"
+    )
+
+    x, y = np.meshgrid(np.linspace(-8, 58, 25), np.linspace(-18, 38, 20))
+    x = x.ravel()
+    y = y.ravel()
+    z = np.zeros_like(x)
+
+    face = grid.search(z, y, x)["FACE"]["index"]
+    n_lost = int(np.count_nonzero(face < 0))
+    assert n_lost == 0, (
+        f"grid search failed for {n_lost} of {len(x)} particles; e.g. (lon, lat)="
+        f"{np.column_stack((x, y))[face < 0][:3].tolist()}"
+    )

--- a/tests/test_uxarray_fieldset.py
+++ b/tests/test_uxarray_fieldset.py
@@ -152,13 +152,6 @@ def test_icon_evals():
     assert np.allclose(fieldset.p.eval(t=tq, z=zq, y=yq, x=xq), zc * (xq + yq))
 
 
-# Constrained (PSLG) Delaunay triangulation of the three nested polygons in
-# docs/user_guide/examples/tutorial_nestedgrids.ipynb, as produced by
-# triangle.triangulate({"vertices": ..., "segments": ...}, "p").
-#
-# Baked in as literals rather than recomputed: py-triangle is only in the "notebooks"
-# pixi feature, not "test", and the notebook's geometry is what #2878 is about, so
-# pinning it also stops the reproducer drifting if the triangulator changes.
 _NESTEDGRIDS_NODES = np.array(
     [
         [10.0, 15.0],
@@ -188,13 +181,13 @@ _NESTEDGRIDS_FACES = np.array(
 )  # fmt: skip
 
 
-@pytest.mark.xfail(reason="#2878 - see tests/test_spatialhash.py and tests/test_index_search.py for the two causes")
-def test_nestedgrids_notebook_triangulation_spherical_search():
-    """Every particle in tutorial_nestedgrids.ipynb must be located on a spherical mesh.
+def test_nestedgrids_triangulation_spherical_search():
+    """Every query point over the mesh's extent must be located by grid.search().
 
-    The notebook reduced to the grid-search step: same triangulation, same 500
-    positions, no fields or kernel. Covers the reported symptom; the two underlying
-    defects are covered separately by the tests named in the xfail reason.
+    The mesh is a single irregular triangulation of three nested polygons, so
+    face size, shape, and orientation all vary widely across it. this causes a broader
+    stress on the spherical search path than a single regular patch of
+    uniform triangles.
     """
     grid = create_uxgrid_from_triangulation(
         _NESTEDGRIDS_NODES[:, 0], _NESTEDGRIDS_NODES[:, 1], _NESTEDGRIDS_FACES, mesh="spherical"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -166,3 +166,101 @@ def assert_cftime_like_particlefile(parquet_path: Path) -> None:
         "CF-time values in Parquet did not get properly decoded. Are the attributes correct?"
     )
     return
+
+
+def create_uxgrid_from_triangulation(node_lon, node_lat, faces, mesh="spherical", z=(0.0, 1.0)):
+    """Wrap a bare triangulation (node lon/lat in degrees, triangles) in a parcels UxGrid."""
+    import uxarray as ux
+
+    from parcels._core.uxgrid import UxGrid
+
+    uxgrid = ux.Grid.from_topology(
+        node_lon=np.asarray(node_lon, dtype=np.float64),
+        node_lat=np.asarray(node_lat, dtype=np.float64),
+        face_node_connectivity=np.asarray(faces, dtype=np.int64),
+    )
+    zc = ux.UxDataArray(np.asarray(z, dtype=np.float64), dims="zf", uxgrid=uxgrid)
+    return UxGrid(uxgrid, zc, mesh=mesh)
+
+
+def create_uxgrid_triangulated_patch(face_deg, centre=(0.0, 0.0), n=8, mesh="spherical"):
+    """Regular ``n`` x ``n`` lon/lat patch of ``face_deg`` quads, split into triangles.
+
+    ``centre`` matters on spherical meshes: the Cartesian coordinate functions have
+    stationary points at lon in {0, +-90, 180} on the equator and at the poles, and a
+    face straddling one varies quadratically rather than linearly there.
+
+    Returns ``(grid, nodes, faces)`` with nodes as (lon, lat) degrees.
+    """
+    half = 0.5 * face_deg * n
+    if abs(centre[1]) + half > 90.0:
+        raise ValueError(
+            f"patch of {n} x {face_deg} deg faces centred at lat {centre[1]} runs past the pole; reduce n or face_deg"
+        )
+    lons = np.linspace(centre[0] - half, centre[0] + half, n + 1)
+    lats = np.linspace(centre[1] - half, centre[1] + half, n + 1)
+    grid_lon, grid_lat = np.meshgrid(lons, lats)
+    nodes = np.column_stack((grid_lon.ravel(), grid_lat.ravel()))
+
+    faces = []
+    for j in range(n):
+        for i in range(n):
+            sw = j * (n + 1) + i
+            se = sw + 1
+            nw = sw + n + 1
+            ne = nw + 1
+            faces.append([sw, se, ne])
+            faces.append([sw, ne, nw])
+    faces = np.asarray(faces, dtype=np.int64)
+
+    grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh=mesh)
+    return grid, nodes, faces
+
+
+# Asymmetric so samples avoid the centroid, edge midpoints, and the shared quad diagonal.
+_INTERIOR_BARYCENTRIC_WEIGHTS = np.array(
+    [
+        [1 / 3, 1 / 3, 1 / 3],
+        [0.70, 0.19, 0.11],
+        [0.11, 0.70, 0.19],
+        [0.19, 0.11, 0.70],
+        [0.46, 0.31, 0.23],
+        [0.23, 0.46, 0.31],
+    ]
+)
+
+
+def sample_points_inside_faces(nodes, faces, weights=None):
+    """Sample points strictly inside each triangle, with the containing face known exactly.
+
+    Triangles are straight-sided in lon/lat, so strictly positive barycentric weights
+    put a point inside its face by construction - no point-in-polygon library needed.
+
+    Returns ``(lon, lat, expected_face)``.
+    """
+    if weights is None:
+        weights = _INTERIOR_BARYCENTRIC_WEIGHTS
+    weights = np.asarray(weights, dtype=np.float64)
+    assert np.all(weights > 0.0), "weights must be strictly positive to lie inside the face"
+    assert np.allclose(weights.sum(axis=1), 1.0), "weights must sum to 1"
+
+    verts = np.asarray(nodes, dtype=np.float64)[np.asarray(faces)]  # (n_face, 3, 2)
+    # (n_face, n_weights, 2)
+    pts = np.einsum("wk,fkc->fwc", weights, verts)
+    expected_face = np.repeat(np.arange(len(faces)), len(weights))
+    return pts[..., 0].ravel(), pts[..., 1].ravel(), expected_face
+
+
+def cartesian_face_bounds_from_vertices(grid):
+    """Per-face Cartesian bounding box from vertices only, as ``SpatialHash`` builds it.
+
+    Lets tests assert on box geometry directly instead of inferring it from a failed query.
+    Returns ``(low, high)``, each shape (n_face, 3).
+    """
+    from parcels._core.index_search import _latlon_rad_to_xyz
+
+    nids = grid.uxgrid.face_node_connectivity.values
+    lon = np.deg2rad(grid.uxgrid.node_lon.values[nids])
+    lat = np.deg2rad(grid.uxgrid.node_lat.values[nids])
+    verts = np.stack(_latlon_rad_to_xyz(lat, lon), axis=-1)  # (n_face, 3, 3)
+    return verts.min(axis=1), verts.max(axis=1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -184,15 +184,35 @@ def create_uxgrid_from_triangulation(node_lon, node_lat, faces, mesh="spherical"
     return UxGrid(uxgrid, zc, mesh=mesh)
 
 
-def create_uxgrid_triangulated_patch(face_deg, centre=(0.0, 0.0), n=8, mesh="spherical"):
-    """Regular ``n`` x ``n`` lon/lat patch of ``face_deg`` quads, split into triangles.
+def create_xgrid_from_lonlat(node_lon, node_lat, mesh="spherical"):
+    """Wrap a 2-D lattice of node coordinates (lon/lat in degrees) in a parcels XGrid.
+
+    Both arrays are shaped ``(ny, nx)`` and hold the grid's nodes, so the grid has
+    ``(ny - 1) x (nx - 1)`` faces. The velocities are zero; only the geometry matters.
+    """
+    ny, nx = np.shape(node_lon)
+    ds = simple_UV_dataset(dims=(2, 2, ny, nx), mesh=mesh).assign_coords(
+        lon=(("YG", "XG"), np.asarray(node_lon, dtype=np.float64)),
+        lat=(("YG", "XG"), np.asarray(node_lat, dtype=np.float64)),
+    )
+    return FieldSet.from_sgrid_conventions(ds, mesh=mesh).U.grid
+
+
+def create_lonlat_patch(face_deg, centre=(0.0, 0.0), n=8, nodes_per_face=3):
+    """Regular ``n`` x ``n`` lon/lat patch of ``face_deg`` quads.
+
+    ``nodes_per_face=4`` keeps each quad whole; ``3`` splits each one along its
+    sw-ne diagonal into two triangles.
 
     ``centre`` matters on spherical meshes: the Cartesian coordinate functions have
     stationary points at lon in {0, +-90, 180} on the equator and at the poles, and a
     face straddling one varies quadratically rather than linearly there.
 
-    Returns ``(grid, nodes, faces)`` with nodes as (lon, lat) degrees.
+    Returns ``(nodes, faces)`` with nodes as (lon, lat) degrees.
     """
+    if nodes_per_face not in (3, 4):
+        raise ValueError(f"nodes_per_face must be 3 or 4, got {nodes_per_face}")
+
     half = 0.5 * face_deg * n
     if abs(centre[1]) + half > 90.0:
         raise ValueError(
@@ -210,54 +230,53 @@ def create_uxgrid_triangulated_patch(face_deg, centre=(0.0, 0.0), n=8, mesh="sph
             se = sw + 1
             nw = sw + n + 1
             ne = nw + 1
-            faces.append([sw, se, ne])
-            faces.append([sw, ne, nw])
-    faces = np.asarray(faces, dtype=np.int64)
-
-    grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh=mesh)
-    return grid, nodes, faces
-
-
-# Asymmetric so samples avoid the centroid, edge midpoints, and the shared quad diagonal.
-_INTERIOR_BARYCENTRIC_WEIGHTS = np.array(
-    [
-        [1 / 3, 1 / 3, 1 / 3],
-        [0.70, 0.19, 0.11],
-        [0.11, 0.70, 0.19],
-        [0.19, 0.11, 0.70],
-        [0.46, 0.31, 0.23],
-        [0.23, 0.46, 0.31],
-    ]
-)
+            if nodes_per_face == 4:
+                faces.append([sw, se, ne, nw])
+            else:
+                faces.append([sw, se, ne])
+                faces.append([sw, ne, nw])
+    return nodes, np.asarray(faces, dtype=np.int64)
 
 
-def sample_points_inside_faces(nodes, faces, weights=None):
-    """Sample points strictly inside each triangle, with the containing face known exactly.
+def sample_points_inside_faces(nodes, faces, weights=None, n_samples=6, seed=0, mesh="spherical"):
+    """Sample points strictly inside each face, with the containing face known exactly.
 
-    Each point is a weighted combination of a face's 3 vertex unit vectors on the
-    sphere, renormalized back onto it (a gnomonic projection). Since any strictly
-    positive weights summing to 1 place the result inside the cone spanned by the 3
-    vertices, the point is guaranteed to lie inside the true geodesic triangle.
+    Each point is a weighted combination of the face's nodes using strictly positive
+    weights that sum to 1, which places it inside the face however many nodes that face
+    has. What counts as inside depends on the mesh, so the combination is taken to
+    match: a flat mesh's faces are straight-sided in lon/lat, so its nodes are combined
+    directly, while a spherical mesh's nodes are combined as unit vectors and the result
+    renormalized back onto the sphere (a gnomonic projection), placing the point inside
+    the face's true geodesic boundary.
+
+    By default ``n_samples`` sets of weights are drawn at random, which needs no
+    knowledge of how many nodes a face has. Pass ``weights`` to place samples at
+    chosen positions instead.
 
     Returns ``(lon, lat, expected_face)``.
     """
+    faces = np.asarray(faces)
     if weights is None:
-        weights = _INTERIOR_BARYCENTRIC_WEIGHTS
+        weights = np.random.default_rng(seed).dirichlet(np.ones(faces.shape[1]), size=n_samples)
     weights = np.asarray(weights, dtype=np.float64)
     assert np.all(weights > 0.0), "weights must be strictly positive to lie inside the face"
     assert np.allclose(weights.sum(axis=1), 1.0), "weights must sum to 1"
+    assert weights.shape[1] == faces.shape[1], "each face node needs a weight"
 
-    node_lon = np.asarray(nodes, dtype=np.float64)[:, 0]
-    node_lat = np.asarray(nodes, dtype=np.float64)[:, 1]
-    vx, vy, vz = _latlon_rad_to_xyz(np.deg2rad(node_lat), np.deg2rad(node_lon))
-    verts = np.stack([vx, vy, vz], axis=-1)[np.asarray(faces)]  # (n_face, 3, 3)
-
-    # (n_face, n_weights, 3)
-    pts = np.einsum("wk,fkc->fwc", weights, verts)
-    pts /= np.linalg.norm(pts, axis=-1, keepdims=True)
-
-    lon = np.degrees(np.arctan2(pts[..., 1], pts[..., 0]))
-    lat = np.degrees(np.arcsin(np.clip(pts[..., 2], -1.0, 1.0)))
+    node_lonlat = np.asarray(nodes, dtype=np.float64)
+    if mesh == "flat":
+        verts = node_lonlat[faces]  # (n_face, nodes_per_face, 2)
+        pts = np.einsum("wk,fkc->fwc", weights, verts)  # (n_face, n_weights, 2)
+        lon, lat = pts[..., 0], pts[..., 1]
+    elif mesh == "spherical":
+        vx, vy, vz = _latlon_rad_to_xyz(np.deg2rad(node_lonlat[:, 1]), np.deg2rad(node_lonlat[:, 0]))
+        verts = np.stack([vx, vy, vz], axis=-1)[faces]  # (n_face, nodes_per_face, 3)
+        pts = np.einsum("wk,fkc->fwc", weights, verts)  # (n_face, n_weights, 3)
+        pts /= np.linalg.norm(pts, axis=-1, keepdims=True)
+        lon = np.degrees(np.arctan2(pts[..., 1], pts[..., 0]))
+        lat = np.degrees(np.arcsin(np.clip(pts[..., 2], -1.0, 1.0)))
+    else:
+        raise ValueError(f"mesh must be 'flat' or 'spherical', got {mesh!r}")
 
     expected_face = np.repeat(np.arange(len(faces)), len(weights))
     return lon.ravel(), lat.ravel(), expected_face

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -249,18 +249,3 @@ def sample_points_inside_faces(nodes, faces, weights=None):
     pts = np.einsum("wk,fkc->fwc", weights, verts)
     expected_face = np.repeat(np.arange(len(faces)), len(weights))
     return pts[..., 0].ravel(), pts[..., 1].ravel(), expected_face
-
-
-def cartesian_face_bounds_from_vertices(grid):
-    """Per-face Cartesian bounding box from vertices only, as ``SpatialHash`` builds it.
-
-    Lets tests assert on box geometry directly instead of inferring it from a failed query.
-    Returns ``(low, high)``, each shape (n_face, 3).
-    """
-    from parcels._core.index_search import _latlon_rad_to_xyz
-
-    nids = grid.uxgrid.face_node_connectivity.values
-    lon = np.deg2rad(grid.uxgrid.node_lon.values[nids])
-    lat = np.deg2rad(grid.uxgrid.node_lat.values[nids])
-    verts = np.stack(_latlon_rad_to_xyz(lat, lon), axis=-1)  # (n_face, 3, 3)
-    return verts.min(axis=1), verts.max(axis=1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,6 +13,7 @@ import xarray as xr
 
 import parcels
 from parcels import FieldSet, Particle, Variable
+from parcels._core.index_search import _latlon_rad_to_xyz
 from parcels._core.xgrid import _FIELD_DATA_ORDERING, XGrid, get_axis_from_dim_name
 from parcels._datasets.structured.generated import simple_UV_dataset
 
@@ -233,8 +234,10 @@ _INTERIOR_BARYCENTRIC_WEIGHTS = np.array(
 def sample_points_inside_faces(nodes, faces, weights=None):
     """Sample points strictly inside each triangle, with the containing face known exactly.
 
-    Triangles are straight-sided in lon/lat, so strictly positive barycentric weights
-    put a point inside its face by construction - no point-in-polygon library needed.
+    Each point is a weighted combination of a face's 3 vertex unit vectors on the
+    sphere, renormalized back onto it (a gnomonic projection). Since any strictly
+    positive weights summing to 1 place the result inside the cone spanned by the 3
+    vertices, the point is guaranteed to lie inside the true geodesic triangle.
 
     Returns ``(lon, lat, expected_face)``.
     """
@@ -244,8 +247,17 @@ def sample_points_inside_faces(nodes, faces, weights=None):
     assert np.all(weights > 0.0), "weights must be strictly positive to lie inside the face"
     assert np.allclose(weights.sum(axis=1), 1.0), "weights must sum to 1"
 
-    verts = np.asarray(nodes, dtype=np.float64)[np.asarray(faces)]  # (n_face, 3, 2)
-    # (n_face, n_weights, 2)
+    node_lon = np.asarray(nodes, dtype=np.float64)[:, 0]
+    node_lat = np.asarray(nodes, dtype=np.float64)[:, 1]
+    vx, vy, vz = _latlon_rad_to_xyz(np.deg2rad(node_lat), np.deg2rad(node_lon))
+    verts = np.stack([vx, vy, vz], axis=-1)[np.asarray(faces)]  # (n_face, 3, 3)
+
+    # (n_face, n_weights, 3)
     pts = np.einsum("wk,fkc->fwc", weights, verts)
+    pts /= np.linalg.norm(pts, axis=-1, keepdims=True)
+
+    lon = np.degrees(np.arctan2(pts[..., 1], pts[..., 0]))
+    lat = np.degrees(np.arcsin(np.clip(pts[..., 2], -1.0, 1.0)))
+
     expected_face = np.repeat(np.arange(len(faces)), len(weights))
-    return pts[..., 0].ravel(), pts[..., 1].ravel(), expected_face
+    return lon.ravel(), lat.ravel(), expected_face

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -184,34 +184,23 @@ def create_uxgrid_from_triangulation(node_lon, node_lat, faces, mesh="spherical"
     return UxGrid(uxgrid, zc, mesh=mesh)
 
 
-def create_xgrid_from_lonlat(node_lon, node_lat, mesh="spherical"):
-    """Wrap a 2-D lattice of node coordinates (lon/lat in degrees) in a parcels XGrid.
+def create_lonlat_grid(grid_type, face_deg, centre=(0.0, 0.0), n=8, mesh="spherical"):
+    """Regular ``n`` x ``n`` lon/lat patch of ``face_deg`` faces, wrapped in a parcels grid.
 
-    Both arrays are shaped ``(ny, nx)`` and hold the grid's nodes, so the grid has
-    ``(ny - 1) x (nx - 1)`` faces. The velocities are zero; only the geometry matters.
-    """
-    ny, nx = np.shape(node_lon)
-    ds = simple_UV_dataset(dims=(2, 2, ny, nx), mesh=mesh).assign_coords(
-        lon=(("YG", "XG"), np.asarray(node_lon, dtype=np.float64)),
-        lat=(("YG", "XG"), np.asarray(node_lat, dtype=np.float64)),
-    )
-    return FieldSet.from_sgrid_conventions(ds, mesh=mesh).U.grid
-
-
-def create_lonlat_patch(face_deg, centre=(0.0, 0.0), n=8, nodes_per_face=3):
-    """Regular ``n`` x ``n`` lon/lat patch of ``face_deg`` quads.
-
-    ``nodes_per_face=4`` keeps each quad whole; ``3`` splits each one along its
-    sw-ne diagonal into two triangles.
+    ``grid_type`` picks how the patch is cut and wrapped: ``"xgrid"`` keeps each quad
+    whole and hands the node lattice to a structured grid, while ``"uxgrid"`` splits each
+    quad along its sw-ne diagonal into two triangles and hands the triangulation to an
+    unstructured grid. The velocities are zero; only the geometry matters.
 
     ``centre`` matters on spherical meshes: the Cartesian coordinate functions have
     stationary points at lon in {0, +-90, 180} on the equator and at the poles, and a
     face straddling one varies quadratically rather than linearly there.
 
-    Returns ``(nodes, faces)`` with nodes as (lon, lat) degrees.
+    Returns ``(grid, nodes, faces)``, with nodes as (lon, lat) degrees and faces indexing
+    into them. Cell ``(j, i)`` of an XGrid is face ``j * n + i``.
     """
-    if nodes_per_face not in (3, 4):
-        raise ValueError(f"nodes_per_face must be 3 or 4, got {nodes_per_face}")
+    if grid_type not in ("uxgrid", "xgrid"):
+        raise ValueError(f"grid_type must be 'uxgrid' or 'xgrid', got {grid_type!r}")
 
     half = 0.5 * face_deg * n
     if abs(centre[1]) + half > 90.0:
@@ -230,12 +219,21 @@ def create_lonlat_patch(face_deg, centre=(0.0, 0.0), n=8, nodes_per_face=3):
             se = sw + 1
             nw = sw + n + 1
             ne = nw + 1
-            if nodes_per_face == 4:
+            if grid_type == "xgrid":
                 faces.append([sw, se, ne, nw])
             else:
                 faces.append([sw, se, ne])
                 faces.append([sw, ne, nw])
-    return nodes, np.asarray(faces, dtype=np.int64)
+    faces = np.asarray(faces, dtype=np.int64)
+
+    if grid_type == "uxgrid":
+        grid = create_uxgrid_from_triangulation(nodes[:, 0], nodes[:, 1], faces, mesh=mesh)
+    else:
+        ds = simple_UV_dataset(dims=(2, 2, n + 1, n + 1), mesh=mesh).assign_coords(
+            lon=(("YG", "XG"), grid_lon), lat=(("YG", "XG"), grid_lat)
+        )
+        grid = FieldSet.from_sgrid_conventions(ds, mesh=mesh).U.grid
+    return grid, nodes, faces
 
 
 def sample_points_inside_faces(nodes, faces, weights=None, n_samples=6, seed=0, mesh="spherical"):


### PR DESCRIPTION
### Description
Issue #2878 raised awareness of two separate bugs:

1. During point in cell checking on spherical unstructured or cuvilinear grids the old code did a projection of the particle position by calculating the direction normal to the face and moving the particle in that direction. This meant that for particles close to the edge of a face the normal projection could project them outside of the cell face, which was incorrect. This could result in a GridSearchingError. 
2. The spatialhash grid bounds were previously calculated only by using the positions of a cell's corners. This does not account for the bulged component of the cell that the use a spherical mesh creates. As a result, the spatialhash grid does not fully enclose spherical grids. 

Both of these issues are magnified for grids that contain large cells, which is why for most of the small celled grids that Parcels is tested on, they did not show up earlier.

The fixes are the following:

1. Change from a projection normal to the face to a gnomonic projection which moves the particle on a ray that extends through the face and the center of the unit sphere. This way particles very close to the edge of their cell remain in the cell after projection.
2. Add a much more extensive bounding box calculation for the spatialhash grid. For any give cell their are three possibilities for its minima/maxima. The first is that is on one of the nodes (this is all that was used for the calculation previously). The second is that the face overlaps a global minama/maxima of the unit sphere, think a face that extends over the North Pole, in this case the minima/maxima can be anywhere on the inside of the face, for this reason we introduce and explicit check to see whether a face contains one of the 6 global minima/maxima of the unit sphere, and if it does set the respective xyz bound accordingly. Third, the minima maxima could sits on the face edge. In this case picture a face that has a bottom edge extending from lon -5 to 5 at a lat of 10, the final node forming the face could sit at lon 0, lat 20. In this case the point lon 0, lat 10 serves as an extrema for the face due to its bulge between longitudes of -5 and 5. However this extrema lies only on an edge rather than on a node, or on a global extrema. These types of points can be calculated analytically by parameterizing the curve between to vertices as a cos function and then determining whether that function has a local extrema along the curve. If it does, then that point is one of the faces extrema, if it doesn't, then the node at the end of the curve is the extrema. I am happy to help put this calculation into the docs that @fluidnumericsJoe is writing up. 

The PR in this state covers the case for unstrucutred grids. Structured curvilinear grids still suffer the same bug and I have yet to implement these fixes there. I'll try and do that tomorrow so this is resolved before the v4 release!

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2878 
- [x] Tests added
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.parcels-code.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt): I guided claude code to generate parts of the new _spherical_triangle_bounds function. I made significant modifications to the output for clarity, structure, and scope. I also guided claude code to modify and improve the new testing associated with the PR. I have thoroughly reviewed and understand all code associated with the PR.

Currently a draft PR until the spherical curvilinear fixes are in.
