### PR TITLE
`datetime` objects in `ParticleSet`

### DIFF
--- a/src/parcels/_core/particleset.py
+++ b/src/parcels/_core/particleset.py
@@ -94,7 +94,7 @@ class ParticleSet:
         assert x.size == y.size and x.size == z.size, "x, y, z don't all have the same lengths"
 
         if t is None or len(t) == 0:
-            # # do not set a time yet (because sign_dt not known)
+            # do not set a time yet (because sign_dt not known)
             t = np.array(np.nan)
         elif isinstance(t[0], (np.datetime64, datetime.datetime, datetime.date)) and self.fieldset.time_interval:
             t_dt64 = t.astype("datetime64[ns]") if not isinstance(t[0], np.datetime64) else t

--- a/src/parcels/_core/particleset.py
+++ b/src/parcels/_core/particleset.py
@@ -94,11 +94,11 @@ class ParticleSet:
         assert x.size == y.size and x.size == z.size, "x, y, z don't all have the same lengths"
 
         if t is None or len(t) == 0:
-            # do not set a time yet (because sign_dt not known)
             t = np.array(np.nan)
-        elif isinstance(t[0], np.datetime64) and self.fieldset.time_interval:
-            t = timedelta_to_float(t - self.fieldset.time_interval.left)
-        elif isinstance(t[0], np.timedelta64):
+        elif isinstance(t[0], (np.datetime64, datetime.datetime, datetime.date)) and self.fieldset.time_interval:
+            t_dt64 = t.astype("datetime64[ns]") if not isinstance(t[0], np.datetime64) else t
+            t = timedelta_to_float(t_dt64 - self.fieldset.time_interval.left)
+        elif isinstance(t[0], (np.timedelta64, datetime.timedelta)):
             t = timedelta_to_float(t)
         else:
             raise TypeError("particle t must be a datetime, timedelta, or date object")

--- a/src/parcels/_core/particleset.py
+++ b/src/parcels/_core/particleset.py
@@ -94,6 +94,7 @@ class ParticleSet:
         assert x.size == y.size and x.size == z.size, "x, y, z don't all have the same lengths"
 
         if t is None or len(t) == 0:
+            # # do not set a time yet (because sign_dt not known)
             t = np.array(np.nan)
         elif isinstance(t[0], (np.datetime64, datetime.datetime, datetime.date)) and self.fieldset.time_interval:
             t_dt64 = t.astype("datetime64[ns]") if not isinstance(t[0], np.datetime64) else t

--- a/tests/test_particleset.py
+++ b/tests/test_particleset.py
@@ -93,9 +93,11 @@ def test_pset_custominit_on_pclass(fieldset, pset_override):
     [
         (np.timedelta64(0, "ns"), does_not_raise()),
         (np.datetime64("2000-01-02T00:00:00"), does_not_raise()),
+        (datetime(2000, 1, 1, 0, 0, 0), does_not_raise()),
+        (datetime(2000, 1, 1, 0, 0, 0).date(), does_not_raise()),
+        (timedelta(seconds=0), does_not_raise()),
         (0.0, pytest.raises(TypeError)),
-        (timedelta(seconds=0), pytest.raises(TypeError)),
-        (datetime(2023, 1, 1, 0, 0, 0), pytest.raises(TypeError)),
+        ("invalid_time_string", pytest.raises(TypeError)),
     ],
 )
 def test_particleset_init_time_type(fieldset, time, expectation):


### PR DESCRIPTION
### Description

This PR enables `ParticleSet.__init__` to handle `datetime` objects. Once ingested, converts `datetime` objects to `np.datetime64`.

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #2884 
- [x] Tests modified
- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.parcels-code.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  - Describe how you used it (e.g., by pasting your prompt): asked for help on where datetime objects are best handled in `__init__` and for updates to tests
