### PR TITLE
Fix pypi-release.yml permissions

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -90,7 +90,8 @@ jobs:
     needs: test-built-dist
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:


### PR DESCRIPTION
### Description

The release workflow failed due to insufficient permissions (due to Zizmor hardening). I'll do a manual release.


````

  Error: Trusted publishing exchange failure: 
  OpenID Connect token retrieval failed: GitHub: missing or insufficient OIDC token permissions, the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable was unset
  
  This generally indicates a workflow configuration error, such as insufficient
  permissions. Make sure that your workflow has `id-token: write` configured
  at the job level, e.g.:
  
  ```yaml
  permissions:
    id-token: write
  ```

````
