### PR TITLE
[DOCS/MAINT] Move CROCO plot to separate cell

### DIFF
--- a/docs/user_guide/examples/tutorial_croco_3D.ipynb
+++ b/docs/user_guide/examples/tutorial_croco_3D.ipynb
@@ -226,8 +226,15 @@
     "    runtime=np.timedelta64(50_000, \"s\"),\n",
     "    dt=np.timedelta64(100, \"s\"),\n",
     "    output_file=outputfile,\n",
-    ")\n",
-    "\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fig, ax = plt.subplots(1, 1, figsize=(6, 4))\n",
     "df = pl.read_parquet(\"croco_particles_noW.parquet\")\n",
     "\n",


### PR DESCRIPTION
The second plot in the CROCO tutorial was not showing because of the `hide-output` tag. This PR moves the plotting to a separate cell, so the plot will automatically show

Since this is such a small/trivial PR,  will not ask for a review and merge on green ticks

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.parcels-code.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

None