### PR TITLE
Reducing test_backends runtime

### DIFF
--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -82,8 +82,8 @@ def run_simulation(ds: xr.Dataset, output_path: Path, backend: BackendT) -> Path
     pfile = parcels.ParticleFile(output_path, outputdt=np.timedelta64(6, "h"))
     pset.execute(
         [AdvectionRK4, delete_particle],
-        runtime=np.timedelta64(3, "D"),
-        dt=np.timedelta64(5, "m"),
+        runtime=np.timedelta64(1, "D"),
+        dt=np.timedelta64(1, "h"),
         output_file=pfile,
     )
 


### PR DESCRIPTION
The current `test_backends.py` script takes almost three minutes to run on my machine; which is I think unnecessary because we can do the same equivalence tests on a shorter simulation with larger time steps. This PR does that and reduces the runtime to ~13 seconds

### Description

### Checklist

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] This PR targets the correct branch (`main` for normal development, `v3-support` for v3 support)

### AI Disclosure

<!--- Please review our AI & contribution guidelines (https://docs.parcels-code.org/en/main/development/policies.html#use-of-ai-in-development). Remove this section if your PR does not contain AI-generated content. --->

None
